### PR TITLE
Openapi type defenisions fix

### DIFF
--- a/src/types/openapi.ts
+++ b/src/types/openapi.ts
@@ -423,6 +423,7 @@ type _CommonParameterObjectFields = {
      * Default value is false.
      */
     required?: boolean;
+    schema?: SchemaObject | ReferenceObject;
 };
 
 type _PathParameterObject = {

--- a/src/types/openapi.ts
+++ b/src/types/openapi.ts
@@ -401,7 +401,7 @@ type _SimpleParam = {
     style?: string;
     explode?: boolean;
     allowReserved?: boolean;
-    schema?: SchemaObject | ReferenceObject;
+    schema: SchemaObject | ReferenceObject;
     example?: unknown;
     exmaples?: Record<string, ExampleObject | ReferenceObject>;
 };
@@ -423,7 +423,6 @@ type _CommonParameterObjectFields = {
      * Default value is false.
      */
     required?: boolean;
-    schema?: SchemaObject | ReferenceObject;
 };
 
 type _PathParameterObject = {


### PR DESCRIPTION
According documentation parameterObject may have "schema" key with ScehmaObject or ReferenceObject within 
https://swagger.io/specification/#parameterObject