### PR TITLE
Tune up rule locations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -453,18 +453,18 @@
             }
         },
         "@types/jest": {
-            "version": "24.0.24",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.24.tgz",
-            "integrity": "sha512-vgaG968EDPSJPMunEDdZvZgvxYSmeH8wKqBlHSkBt1pV2XlLEVDzsj1ZhLuI4iG4Pv841tES61txSBF0obh4CQ==",
+            "version": "24.9.1",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
+            "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
             "dev": true,
             "requires": {
                 "jest-diff": "^24.3.0"
             }
         },
         "@types/js-yaml": {
-            "version": "3.12.1",
-            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz",
-            "integrity": "sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==",
+            "version": "3.12.4",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.4.tgz",
+            "integrity": "sha512-fYMgzN+9e28R81weVN49inn/u798ruU91En1ZnGvSZzCRc5jXx9B2EDhlRaWmcO1RIxFHL8AajRXzxDuJu93+A==",
             "dev": true
         },
         "@types/json-schema": {
@@ -498,9 +498,9 @@
             }
         },
         "@types/mime-db": {
-            "version": "1.27.0",
-            "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.27.0.tgz",
-            "integrity": "sha1-m8AUof0f30dknBpUxt15ZrgoR5I=",
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.0.tgz",
+            "integrity": "sha512-nCqnKWfvDzTVRh8NS9Zn+rnZYs5+iw5hx3G0nFgKM/R2mJQwPChin4DQ4zXlXnxTtc/3Ys5FnWweKW6NW+d2aw==",
             "dev": true
         },
         "@types/minimist": {
@@ -510,18 +510,32 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.12.22",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.22.tgz",
-            "integrity": "sha512-r5i93jqbPWGXYXxianGATOxTelkp6ih/U0WVnvaqAvTqM+0U6J3kw6Xk6uq/dWNRkEVw/0SLcO5ORXbVNz4FMQ==",
+            "version": "12.12.47",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+            "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A==",
             "dev": true
         },
         "@types/node-fetch": {
-            "version": "2.5.4",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
-            "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+            "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "*",
+                "form-data": "^3.0.0"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+                    "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                }
             }
         },
         "@types/parse-json": {
@@ -689,9 +703,9 @@
             }
         },
         "arg": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
-            "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
             "dev": true
         },
         "argparse": {
@@ -1394,9 +1408,9 @@
             "dev": true
         },
         "diff": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-            "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
         },
         "diff-sequences": {
@@ -3815,9 +3829,9 @@
             }
         },
         "make-error": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-            "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
         },
         "makeerror": {
@@ -5370,9 +5384,9 @@
             }
         },
         "ts-jest": {
-            "version": "24.2.0",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.2.0.tgz",
-            "integrity": "sha512-Yc+HLyldlIC9iIK8xEN7tV960Or56N49MDP7hubCZUeI7EbIOTsas6rXCMB4kQjLACJ7eDOF4xWEO5qumpKsag==",
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.3.0.tgz",
+            "integrity": "sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==",
             "dev": true,
             "requires": {
                 "bs-logger": "0.x",
@@ -5411,16 +5425,28 @@
             }
         },
         "ts-node": {
-            "version": "8.5.4",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
-            "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+            "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
             "dev": true,
             "requires": {
                 "arg": "^4.1.0",
                 "diff": "^4.0.1",
                 "make-error": "^1.1.1",
-                "source-map-support": "^0.5.6",
-                "yn": "^3.0.0"
+                "source-map-support": "^0.5.17",
+                "yn": "3.1.1"
+            },
+            "dependencies": {
+                "source-map-support": {
+                    "version": "0.5.19",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+                    "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                }
             }
         },
         "tslib": {
@@ -5469,9 +5495,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
-            "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
+            "version": "3.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+            "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
             "dev": true
         },
         "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
         "url": "https://github.com/antonk52/swaggerlint/issues"
     },
     "devDependencies": {
-        "@types/jest": "^24.0.23",
-        "@types/js-yaml": "^3.12.1",
+        "@types/jest": "^24.9.1",
+        "@types/js-yaml": "^3.12.4",
         "@types/lodash.get": "^4.4.6",
         "@types/lodash.merge": "^4.6.6",
-        "@types/mime-db": "^1.27.0",
+        "@types/mime-db": "^1.43.0",
         "@types/minimist": "^1.2.0",
-        "@types/node": "^12.12.17",
-        "@types/node-fetch": "^2.5.4",
+        "@types/node": "^12.12.47",
+        "@types/node-fetch": "^2.5.7",
         "@typescript-eslint/eslint-plugin": "^2.12.0",
         "@typescript-eslint/parser": "^2.12.0",
         "eslint": "^6.7.2",
@@ -45,9 +45,9 @@
         "jest": "^24.9.0",
         "lodash.merge": "^4.6.2",
         "prettier": "^1.19.1",
-        "ts-jest": "^24.2.0",
-        "ts-node": "^8.5.4",
-        "typescript": "^3.9.2"
+        "ts-jest": "^24.3.0",
+        "ts-node": "^8.10.2",
+        "typescript": "^3.9.5"
     },
     "dependencies": {
         "case": "^1.6.2",

--- a/src/rules/expressive-path-summary/index.ts
+++ b/src/rules/expressive-path-summary/index.ts
@@ -5,12 +5,13 @@ const name = 'expressive-path-summary';
 const rule: SwaggerlintRule = {
     name,
     visitor: {
-        OperationObject: ({node, report}): void => {
+        OperationObject: ({node, report, location}): void => {
             const {summary} = node;
-            if (summary) {
+            if (typeof summary === 'string') {
                 if (summary.split(' ').length < 2) {
                     report(
                         `Every path summary should contain at least 2 words. This has "${summary}"`,
+                        [...location, 'summary'],
                     );
                 }
             } else {

--- a/src/rules/expressive-path-summary/spec/index.spec.ts
+++ b/src/rules/expressive-path-summary/spec/index.spec.ts
@@ -1,7 +1,6 @@
 import rule from '../';
 import {Swagger, SwaggerlintConfig} from '../../../types';
 import {swaggerlint} from '../../../';
-import _merge from 'lodash.merge';
 
 const swaggerSample: Swagger.SwaggerObject = {
     swagger: '2.0',

--- a/src/rules/expressive-path-summary/spec/index.spec.ts
+++ b/src/rules/expressive-path-summary/spec/index.spec.ts
@@ -1,0 +1,108 @@
+import rule from '../';
+import {Swagger, SwaggerlintConfig} from '../../../types';
+import {swaggerlint} from '../../../';
+import _merge from 'lodash.merge';
+
+const swaggerSample: Swagger.SwaggerObject = {
+    swagger: '2.0',
+    info: {
+        title: 'stub',
+        version: '1.0',
+    },
+    paths: {
+        '/some/api/path': {
+            get: {
+                tags: ['random'],
+                summary: 'upload-image',
+                description: '',
+                consumes: ['multipart/form-data'],
+                produces: ['application/json'],
+                responses: {
+                    '200': {
+                        description: 'successful operation',
+                        schema: {
+                            $ref: '#/definitions/ApiResponse',
+                        },
+                    },
+                },
+            },
+            post: {
+                tags: ['random'],
+                description: '',
+                consumes: ['multipart/form-data'],
+                produces: ['application/json'],
+                responses: {
+                    '200': {
+                        description: 'successful operation',
+                        schema: {
+                            $ref: '#/definitions/ApiResponse',
+                        },
+                    },
+                },
+            },
+            delete: {
+                tags: ['random'],
+                summary: '',
+                description: '',
+                consumes: ['multipart/form-data'],
+                produces: ['application/json'],
+                responses: {
+                    '200': {
+                        description: 'successful operation',
+                        schema: {
+                            $ref: '#/definitions/ApiResponse',
+                        },
+                    },
+                },
+            },
+            patch: {
+                tags: ['random'],
+                summary:
+                    'wonderful summary, well described the meaning of this endpoint method.',
+                description: '',
+                consumes: ['multipart/form-data'],
+                produces: ['application/json'],
+                responses: {
+                    '200': {
+                        description: 'successful operation',
+                        schema: {
+                            $ref: '#/definitions/ApiResponse',
+                        },
+                    },
+                },
+            },
+        },
+    },
+    tags: [],
+};
+
+describe(`rule "${rule.name}"`, () => {
+    const config: SwaggerlintConfig = {
+        rules: {
+            [rule.name]: true,
+        },
+    };
+
+    it('should error for missing and poor path summaries', () => {
+        const result = swaggerlint(swaggerSample, config);
+
+        const invalidSummary = {
+            location: ['paths', '/some/api/path', 'get', 'summary'],
+            msg:
+                'Every path summary should contain at least 2 words. This has "upload-image"',
+            name: rule.name,
+        };
+        const emptySummary = {
+            location: ['paths', '/some/api/path', 'delete', 'summary'],
+            msg:
+                'Every path summary should contain at least 2 words. This has ""',
+            name: rule.name,
+        };
+        const missingSummary = {
+            location: ['paths', '/some/api/path', 'post'],
+            msg: 'Every path has to have summary.',
+            name: rule.name,
+        };
+        expect(result).toEqual([invalidSummary, missingSummary, emptySummary]);
+    });
+});

--- a/src/rules/latin-definitions-only/index.ts
+++ b/src/rules/latin-definitions-only/index.ts
@@ -5,7 +5,7 @@ const name = 'latin-definitions-only';
 const rule: SwaggerlintRule = {
     name,
     visitor: {
-        DefinitionsObject: ({node, report}): void => {
+        DefinitionsObject: ({node, report, location}): void => {
             Object.keys(node).forEach(name => {
                 const rest = name
                     // def name may contain latin chars
@@ -16,6 +16,7 @@ const rule: SwaggerlintRule = {
                 if (rest.length > 0) {
                     report(
                         `Definition name "${name}" contains non latin characters.`,
+                        [...location, name],
                     );
                 }
             });

--- a/src/rules/no-trailing-slash/index.ts
+++ b/src/rules/no-trailing-slash/index.ts
@@ -5,12 +5,15 @@ const name = 'no-trailing-slash';
 const rule: SwaggerlintRule = {
     name,
     visitor: {
-        PathsObject: ({node, report}): void => {
+        PathsObject: ({node, report, location}): void => {
             const urls = Object.keys(node);
 
             urls.forEach(url => {
                 if (url.endsWith('/')) {
-                    report(`Url cannot end with a slash "${url}".`);
+                    report(`Url cannot end with a slash "${url}".`, [
+                        ...location,
+                        url,
+                    ]);
                 }
             });
         },
@@ -18,7 +21,7 @@ const rule: SwaggerlintRule = {
             const {host} = node;
 
             if (typeof host === 'string' && host.endsWith('/')) {
-                report('Host url cannot end with a slash.');
+                report('Host url cannot end with a slash.', ['host']);
             }
         },
     },

--- a/src/rules/no-trailing-slash/spec/index.spec.ts
+++ b/src/rules/no-trailing-slash/spec/index.spec.ts
@@ -61,7 +61,7 @@ describe(`rule "${rule.name}"`, () => {
             {
                 msg: 'Url cannot end with a slash "/url/".',
                 name: 'no-trailing-slash',
-                location: ['paths'],
+                location: ['paths', '/url/'],
             },
         ];
 
@@ -78,7 +78,7 @@ describe(`rule "${rule.name}"`, () => {
             {
                 msg: 'Host url cannot end with a slash.',
                 name: 'no-trailing-slash',
-                location: [],
+                location: ['host'],
             },
         ];
 

--- a/src/rules/object-prop-casing/index.ts
+++ b/src/rules/object-prop-casing/index.ts
@@ -37,7 +37,7 @@ const rule: SwaggerlintRule = {
                                         ? ` Should be "${correctVersion}".`
                                         : ''
                                 }`,
-                                [...location, 'properties'],
+                                [...location, 'properties', propName],
                             );
                         }
                     });

--- a/src/rules/object-prop-casing/spec/index.spec.ts
+++ b/src/rules/object-prop-casing/spec/index.spec.ts
@@ -64,25 +64,25 @@ describe(`rule "${rule.name}"`, () => {
                 msg:
                     'Property "some-casing" has wrong casing. Should be "someCasing".',
                 name: 'object-prop-casing',
-                location,
+                location: [...location, 'some-casing'],
             },
             {
                 msg:
                     'Property "some_casing" has wrong casing. Should be "someCasing".',
                 name: 'object-prop-casing',
-                location,
+                location: [...location, 'some_casing'],
             },
             {
                 msg:
                     'Property "SOME_CASING" has wrong casing. Should be "someCasing".',
                 name: 'object-prop-casing',
-                location,
+                location: [...location, 'SOME_CASING'],
             },
             {
                 msg:
                     'Property "SomeCasing" has wrong casing. Should be "someCasing".',
                 name: 'object-prop-casing',
-                location,
+                location: [...location, 'SomeCasing'],
             },
         ];
 
@@ -122,7 +122,12 @@ describe(`rule "${rule.name}"`, () => {
                 [rule.name]: ['camel', {ignore: ['SOME_CASING', 'SomeCasing']}],
             },
         });
-        const location = ['definitions', 'lolkekDTO', 'properties'];
+        const location = [
+            'definitions',
+            'lolkekDTO',
+            'properties',
+            'some-casing',
+        ];
         const expected = [
             {
                 msg:

--- a/src/rules/only-valid-mime-types/readme.md
+++ b/src/rules/only-valid-mime-types/readme.md
@@ -1,6 +1,6 @@
 # only-valid-mime-types
 
-By default this rule is checking the mime types specified in `consumes` and `produces` properties in `SwaggerObject` and `OperationObject`.
+By default this rule is checking the mime types specified in `consumes` and `produces` properties in `SwaggerObject` and `OperationObject`. Verification happens against the [`mime-db`](https://npmjs.org/package/mime-db).
 
 ```js
 // swaggerlint.config.js

--- a/src/rules/only-valid-mime-types/readme.md
+++ b/src/rules/only-valid-mime-types/readme.md
@@ -1,0 +1,12 @@
+# only-valid-mime-types
+
+By default this rule is checking the mime types specified in `consumes` and `produces` properties in `SwaggerObject` and `OperationObject`.
+
+```js
+// swaggerlint.config.js
+module.exports = {
+    rules: {
+        'only-valid-mime-types': true,
+    },
+};
+```

--- a/src/rules/parameter-casing/index.ts
+++ b/src/rules/parameter-casing/index.ts
@@ -24,7 +24,7 @@ const PARAMETER_LOCATIONS: Swagger.ParameterObject['in'][] = [
 const rule: SwaggerlintRule = {
     name,
     visitor: {
-        ParameterObject: ({node, report, setting}): void => {
+        ParameterObject: ({node, report, location, setting}): void => {
             if (typeof setting === 'boolean') return;
 
             const [settingCasingName, opts = {}] = setting;
@@ -77,6 +77,7 @@ const rule: SwaggerlintRule = {
                                 ? ` Should be "${correctVersion}".`
                                 : ''
                         }`,
+                        [...location, 'name'],
                     );
                 }
             }

--- a/src/rules/parameter-casing/spec/index.spec.ts
+++ b/src/rules/parameter-casing/spec/index.spec.ts
@@ -72,19 +72,19 @@ describe(`rule "${rule.name}"`, () => {
                 msg:
                     'Parameter "PET_STORE" has wrong casing. Should be "petStore".',
                 name: 'parameter-casing',
-                location: ['paths', '/url', 'parameters', '1'],
+                location: ['paths', '/url', 'parameters', '1', 'name'],
             },
             {
                 msg:
                     'Parameter "pet-age" has wrong casing. Should be "petAge".',
                 name: 'parameter-casing',
-                location: ['paths', '/url', 'parameters', '2'],
+                location: ['paths', '/url', 'parameters', '2', 'name'],
             },
             {
                 msg:
                     'Parameter "pet_color" has wrong casing. Should be "petColor".',
                 name: 'parameter-casing',
-                location: ['paths', '/url', 'parameters', '3'],
+                location: ['paths', '/url', 'parameters', '3', 'name'],
             },
         ];
 
@@ -139,7 +139,7 @@ describe(`rule "${rule.name}"`, () => {
                 msg:
                     'Parameter "pet_color" has wrong casing. Should be "petColor".',
                 name: 'parameter-casing',
-                location: ['paths', '/url', 'parameters', '3'],
+                location: ['paths', '/url', 'parameters', '3', 'name'],
             },
         ];
 

--- a/src/rules/required-parameter-description/index.ts
+++ b/src/rules/required-parameter-description/index.ts
@@ -5,9 +5,16 @@ const name = 'required-parameter-description';
 const rule: SwaggerlintRule = {
     name,
     visitor: {
-        ParameterObject: ({node, report}): void => {
-            if (!('description' in node) || !node.description) {
+        ParameterObject: ({node, report, location}): void => {
+            if (!('description' in node)) {
                 report(`"${node.name}" parameter is missing description.`);
+                return;
+            }
+            if (typeof node.description === 'string' && !node.description) {
+                report(`"${node.name}" parameter is missing description.`, [
+                    ...location,
+                    'description',
+                ]);
             }
         },
     },

--- a/src/rules/required-parameter-description/readme.md
+++ b/src/rules/required-parameter-description/readme.md
@@ -1,0 +1,12 @@
+# required-parameter-description rule
+
+This rule checks for all parameters in `ParameterObject` to have `description`.
+
+```js
+// swaggerlint.config.js
+module.exports = {
+    rules: {
+        'required-parameter-description': true,
+    },
+};
+```

--- a/src/rules/required-parameter-description/spec/index.spec.ts
+++ b/src/rules/required-parameter-description/spec/index.spec.ts
@@ -72,6 +72,12 @@ describe(`rule "${rule.name}"`, () => {
                     required: true,
                     type: 'string',
                 },
+                {
+                    name: 'emptyDesc',
+                    in: 'query',
+                    description: '',
+                    type: 'string',
+                },
             ],
         };
         const modConfig = _merge(mod, swaggerSample);
@@ -91,6 +97,11 @@ describe(`rule "${rule.name}"`, () => {
                 msg: '"petAge" parameter is missing description.',
                 name: 'required-parameter-description',
                 location: ['parameters', '0'],
+            },
+            {
+                msg: '"emptyDesc" parameter is missing description.',
+                name: 'required-parameter-description',
+                location: ['parameters', '2', 'description'],
             },
         ];
 

--- a/src/spec/swaggerlint.spec.ts
+++ b/src/spec/swaggerlint.spec.ts
@@ -12,6 +12,9 @@ jest.mock('../rules', () => ({
         visitor: {},
         isValidSetting: jest.fn(() => true),
     },
+    'always-valid-rule': {
+        visitor: {},
+    },
 }));
 
 describe('swaggerlint', () => {
@@ -69,7 +72,7 @@ describe('swaggerlint', () => {
         ]);
     });
 
-    it('has no errors when rules are off', () => {
+    it('has an error when no rules are enabled', () => {
         const walker = require('../walker');
         walker.mockReturnValueOnce({
             visitors: {
@@ -85,7 +88,14 @@ describe('swaggerlint', () => {
 
         const result = swaggerlint(swagger, config);
 
-        expect(result).toEqual([]);
+        expect(result).toEqual([
+            {
+                location: [],
+                msg:
+                    'Found 0 enabled rules. Swaggerlint requires at least one rule enabled.',
+                name: 'swaggerlint-core',
+            },
+        ]);
     });
 
     it('returns an error when rule setting validation does not pass', () => {
@@ -102,6 +112,7 @@ describe('swaggerlint', () => {
         const config: SwaggerlintConfig = {
             rules: {
                 'known-rule': ['invalid-setting'],
+                'always-valid-rule': true,
             },
         };
         const result = swaggerlint(swagger, config);

--- a/src/types/swagger.ts
+++ b/src/types/swagger.ts
@@ -114,7 +114,7 @@ export type ParameterObject =
     | {
           name: string;
           in: 'body';
-          description: string;
+          description?: string;
           required?: boolean;
           schema: SchemaObject;
       }
@@ -124,13 +124,14 @@ export type ParameterObject =
     | {
           name: string;
           in: 'path';
+          description?: string;
           required: true;
           type: 'string' | 'number' | 'integer' | 'boolean';
       }
     | {
           name: string;
           in: 'query' | 'header' | 'formData';
-          description: string;
+          description?: string;
           required?: boolean;
           type: 'string';
           format?: StringFormat;
@@ -144,7 +145,7 @@ export type ParameterObject =
     | {
           name: string;
           in: 'query' | 'header' | 'formData';
-          description: string;
+          description?: string;
           required?: boolean;
           type: 'number';
           format?: NumberFormat;
@@ -160,7 +161,7 @@ export type ParameterObject =
     | {
           name: string;
           in: 'query' | 'header' | 'formData';
-          description: string;
+          description?: string;
           required?: boolean;
           type: 'integer';
           format?: IntegerFormat;
@@ -176,7 +177,7 @@ export type ParameterObject =
     | {
           name: string;
           in: 'query' | 'header' | 'formData';
-          description: string;
+          description?: string;
           required?: boolean;
           type: 'boolean';
           default?: boolean;
@@ -188,7 +189,7 @@ export type ParameterObject =
     | {
           name: string;
           in: 'formData';
-          description: string;
+          description?: string;
           required?: boolean;
           type: 'file';
           default?: unknown;
@@ -200,7 +201,7 @@ export type ParameterObject =
     | {
           name: string;
           in: 'query' | 'header' | 'formData';
-          description: string;
+          description?: string;
           required?: boolean;
           type: 'array';
           items: ItemsObject;

--- a/src/types/swaggerlint.ts
+++ b/src/types/swaggerlint.ts
@@ -19,7 +19,10 @@ export type CliResult = {
 
 type AbstractObject = Record<string, unknown>;
 
-type SwaggerlintRuleSetting = [string, AbstractObject] | [string] | boolean;
+export type SwaggerlintRuleSetting =
+    | [string, AbstractObject]
+    | [string]
+    | boolean;
 
 export type ConfigIgnore = {
     definitions?: string[];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -87,6 +87,24 @@ export function hasKey<K extends string>(
     return key in obj;
 }
 
+export function isInfoObject(arg: unknown): arg is Swagger.InfoObject {
+    return (
+        isObject(arg) &&
+        hasKey('title', arg) &&
+        hasKey('version', arg) &&
+        typeof arg.title === 'string' &&
+        typeof arg.version === 'string'
+    );
+}
+
 export function isSwaggerObject(arg: unknown): arg is Swagger.SwaggerObject {
-    return isObject(arg) && hasKey('swagger', arg) && arg.swagger === '2.0';
+    return (
+        isObject(arg) &&
+        hasKey('swagger', arg) &&
+        arg.swagger === '2.0' &&
+        hasKey('info', arg) &&
+        hasKey('paths', arg) &&
+        isObject(arg.paths) &&
+        isInfoObject(arg.info)
+    );
 }


### PR DESCRIPTION
This PR includes error's location improvements:

-   `expressive-path-summary` error location points at summary if present
-   `parameter-casing` error location points at `name` prop value
-   `ParameterObject` type has **optional** `description` property
-   `latin-definitions-only`, `no-trailing-slash` & `object-prop-casing` errors now contain the property name causing the error as the last element in the location
-   refined `required-parameter-description` error with more precise location

It also includes general improvements
-   test out every rule to verify the error location points at the correct node
-   core-error for no enabled rules
-   improved `isSwaggerObject` verification
-   docs for `only-valid-mime-types` & `required-parameter-description`
-   update typescript, types and mime-db
