### PR TITLE
Open api rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ You can set any rule value to `false` to disable it or to `true` to enable and s
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------- |
 | [`object-prop-casing`](./src/rules/object-prop-casing/readme.md)                         | Casing for your object property names.                                          | `camel` |
 | [`no-empty-object-type`](./src/rules/no-empty-object-type/readme.md)                     | Object types have to have their properties specified.                           |
+| [`no-inline-enums`](./src/rules/no-inline-enums/readme.md)                               | Enums must be in DefinitionsObject or ComponentsObject.                         |
 | [`no-single-allof`](./src/rules/no-single-allof/readme.md)                               | Object types should not have a redundant single `allOf` property.               |
 | [`latin-definitions-only`](./src/rules/latin-definitions-only/readme.md)                 | Error when non Latin characters used in definition names.                       |
 | [`path-param-required-field`](./src/rules/path-param-required-field/readme.md)           | Helps to keep consistently set optional `required` property in path parameters. |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ You can set any rule value to `false` to disable it or to `true` to enable and s
 | [`expressive-path-summary`](./src/rules/expressive-path-summary/readme.md)               | Helps to have an intentional summary.                                           |
 | [`latin-definitions-only`](./src/rules/latin-definitions-only/readme.md)                 | Error when non Latin characters used in definition names.                       |
 | [`no-empty-object-type`](./src/rules/no-empty-object-type/readme.md)                     | Object types have to have their properties specified.                           |
+| [`no-external-refs`](./src/rules/no-external-refs/readme.md)                             | Bans ReferenceObjects with external refferences.                                |
 | [`no-inline-enums`](./src/rules/no-inline-enums/readme.md)                               | Enums must be in DefinitionsObject or ComponentsObject.                         |
 | [`no-single-allof`](./src/rules/no-single-allof/readme.md)                               | Object types should not have a redundant single `allOf` property.               |
 | [`no-trailing-slash`](./src/rules/no-trailing-slash/readme.md)                           | All URLs must NOT end with a slash.                                             |

--- a/README.md
+++ b/README.md
@@ -85,19 +85,19 @@ You can set any rule value to `false` to disable it or to `true` to enable and s
 
 | rule name                                                                                | description                                                                     | default |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------- |
-| [`object-prop-casing`](./src/rules/object-prop-casing/readme.md)                         | Casing for your object property names.                                          | `camel` |
+| [`expressive-path-summary`](./src/rules/expressive-path-summary/readme.md)               | Helps to have an intentional summary.                                           |
+| [`latin-definitions-only`](./src/rules/latin-definitions-only/readme.md)                 | Error when non Latin characters used in definition names.                       |
 | [`no-empty-object-type`](./src/rules/no-empty-object-type/readme.md)                     | Object types have to have their properties specified.                           |
 | [`no-inline-enums`](./src/rules/no-inline-enums/readme.md)                               | Enums must be in DefinitionsObject or ComponentsObject.                         |
 | [`no-single-allof`](./src/rules/no-single-allof/readme.md)                               | Object types should not have a redundant single `allOf` property.               |
-| [`latin-definitions-only`](./src/rules/latin-definitions-only/readme.md)                 | Error when non Latin characters used in definition names.                       |
-| [`path-param-required-field`](./src/rules/path-param-required-field/readme.md)           | Helps to keep consistently set optional `required` property in path parameters. |
-| [`expressive-path-summary`](./src/rules/expressive-path-summary/readme.md)               | Helps to have an intentional summary.                                           |
+| [`no-trailing-slash`](./src/rules/no-trailing-slash/readme.md)                           | All URLs must NOT end with a slash.                                             |
+| [`object-prop-casing`](./src/rules/object-prop-casing/readme.md)                         | Casing for your object property names.                                          | `camel` |
 | [`only-valid-mime-types`](./src/rules/only-valid-mime-types/readme.md)                   | Checks mime types against known from [`mime-db`](https://npm.im/mime-db).       |
 | [`parameter-casing`](./src/rules/parameter-casing/readme.md)                             | Casing for your parameters.                                                     | `camel` |
+| [`path-param-required-field`](./src/rules/path-param-required-field/readme.md)           | Helps to keep consistently set optional `required` property in path parameters. |
 | [`required-operation-tags`](./src/rules/required-operation-tags/readme.md)               | All operations must have tags.                                                  |
-| [`required-tag-description`](./src/rules/required-tag-description/readme.md)             | All tags must have description.                                                 |
 | [`required-parameter-description`](./src/rules/required-parameter-description/readme.md) | All parameters must have description.                                           |
-| [`no-trailing-slash`](./src/rules/no-trailing-slash/readme.md)                           | All URLs must NOT end with a slash.                                             |
+| [`required-tag-description`](./src/rules/required-tag-description/readme.md)             | All tags must have description.                                                 |
 
 Additionally see the docs for additional settings for [`obj-prop-casing`](./src/rules/object-prop-casing/readme.md) and [`parameter-casing`](./src/rules/parameter-casing/readme.md).
 

--- a/docs/how-to-write-a-rule.md
+++ b/docs/how-to-write-a-rule.md
@@ -148,3 +148,5 @@ export default myCustomRule
 ## How to add a rule to core `swaggerlint` rules
 
 After you wrote your rule you can propose to add it to default `swaggerlint` rules. To do so you need to add it to [`rules` directory](../src/rules/) and [`src/rules/index.ts` file](../src/rules/index.ts). After this you can create a PR, it is a good idea to explain on why you think adding this rule is a good idea.
+
+Do not forget to add your rule to the project README to make it discoverable.

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -5,6 +5,8 @@ const config: SwaggerlintConfig = {
         'expressive-path-summary': true,
         'latin-definitions-only': true,
         'no-empty-object-type': true,
+        'no-external-refs': false,
+        'no-inline-enums': true,
         'no-single-allof': true,
         'no-trailing-slash': true,
         'object-prop-casing': ['camel'],

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,6 +1,7 @@
 import expressivePathSummary from './expressive-path-summary';
 import latinDefinitionsOnly from './latin-definitions-only';
 import noEmptyObjectType from './no-empty-object-type';
+import noInlineEnums from './no-inline-enums';
 import noSingleOneof from './no-single-allof';
 import noTrailingSlash from './no-trailing-slash';
 import objPropCasing from './object-prop-casing';
@@ -17,6 +18,7 @@ const rules: Record<string, SwaggerlintRule> = {
     [expressivePathSummary.name]: expressivePathSummary,
     [latinDefinitionsOnly.name]: latinDefinitionsOnly,
     [noEmptyObjectType.name]: noEmptyObjectType,
+    [noInlineEnums.name]: noInlineEnums,
     [noSingleOneof.name]: noSingleOneof,
     [noTrailingSlash.name]: noTrailingSlash,
     [objPropCasing.name]: objPropCasing,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,6 +1,7 @@
 import expressivePathSummary from './expressive-path-summary';
 import latinDefinitionsOnly from './latin-definitions-only';
 import noEmptyObjectType from './no-empty-object-type';
+import noExternalRefs from './no-external-refs';
 import noInlineEnums from './no-inline-enums';
 import noSingleOneof from './no-single-allof';
 import noTrailingSlash from './no-trailing-slash';
@@ -18,6 +19,7 @@ const rules: Record<string, SwaggerlintRule> = {
     [expressivePathSummary.name]: expressivePathSummary,
     [latinDefinitionsOnly.name]: latinDefinitionsOnly,
     [noEmptyObjectType.name]: noEmptyObjectType,
+    [noExternalRefs.name]: noExternalRefs,
     [noInlineEnums.name]: noInlineEnums,
     [noSingleOneof.name]: noSingleOneof,
     [noTrailingSlash.name]: noTrailingSlash,

--- a/src/rules/no-external-refs/index.ts
+++ b/src/rules/no-external-refs/index.ts
@@ -1,0 +1,16 @@
+import {SwaggerlintRule} from '../../types';
+
+const name = 'no-external-refs';
+
+const rule: SwaggerlintRule = {
+    name,
+    openapiVisitor: {
+        ReferenceObject: ({node, report}): void => {
+            if (!node.$ref.startsWith('#')) {
+                report('External references are banned.');
+            }
+        },
+    },
+};
+
+export default rule;

--- a/src/rules/no-external-refs/readme.md
+++ b/src/rules/no-external-refs/readme.md
@@ -1,0 +1,19 @@
+# no-external-refs
+
+This rule bans the use of `ReferenceObjects` referring to external files.
+
+This rule only applies to OpenAPI.
+
+## Examples of valid and invalid OpenAPI ReferenceObjects
+
+```yaml
+components:
+    schemas:
+        Example:
+            type: 'object'
+            properties:
+                foo:
+                    $ref: '#/components/schemas/Foo' # <-- valid
+                bar:
+                    $ref: 'schemas.yaml#/Bar' # <-- invalid
+```

--- a/src/rules/no-external-refs/spec/index.spec.ts
+++ b/src/rules/no-external-refs/spec/index.spec.ts
@@ -1,0 +1,58 @@
+import rule from '../';
+import {SwaggerlintConfig, OpenAPI} from '../../../types';
+import {swaggerlint} from '../../../';
+import {getOpenAPIObject} from '../../../utils/tests';
+
+describe(`rule "${rule.name}"`, () => {
+    const config: SwaggerlintConfig = {
+        rules: {
+            [rule.name]: true,
+        },
+    };
+
+    describe('OpenAPI', () => {
+        it('should NOT error for an empty openapi sample', () => {
+            const result = swaggerlint(getOpenAPIObject({}), config);
+
+            expect(result).toEqual([]);
+        });
+
+        it('should error for an external reference object', () => {
+            const mod: Partial<OpenAPI.OpenAPIObject> = {
+                components: {
+                    schemas: {
+                        Example: {
+                            type: 'object',
+                            properties: {
+                                foo: {
+                                    $ref: '#/components/schemas/Foo',
+                                },
+                                bar: {
+                                    $ref: 'schemas.yaml#/Bar',
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+            const modConfig = getOpenAPIObject(mod);
+            const result = swaggerlint(modConfig, config);
+            const location = [
+                'components',
+                'schemas',
+                'Example',
+                'properties',
+                'bar',
+            ];
+            const expected = [
+                {
+                    msg: 'External references are banned.',
+                    name: rule.name,
+                    location,
+                },
+            ];
+
+            expect(result).toEqual(expected);
+        });
+    });
+});

--- a/src/rules/no-inline-enums/index.ts
+++ b/src/rules/no-inline-enums/index.ts
@@ -1,0 +1,27 @@
+import {SwaggerlintRule} from '../../types';
+
+const name = 'no-inline-enums';
+
+const rule: SwaggerlintRule = {
+    name,
+    swaggerVisitor: {
+        SchemaObject: ({node, report, location}): void => {
+            if (node.enum && location[0] !== 'definitions') {
+                report(
+                    'Inline enums are not allowed. Move this SchemaObject to DefinitionsObject',
+                );
+            }
+        },
+    },
+    openapiVisitor: {
+        SchemaObject: ({node, report, location}): void => {
+            if (node.enum && location[0] !== 'components') {
+                report(
+                    'Inline enums are not allowed. Move this SchemaObject to ComponentsObject',
+                );
+            }
+        },
+    },
+};
+
+export default rule;

--- a/src/rules/no-inline-enums/readme.md
+++ b/src/rules/no-inline-enums/readme.md
@@ -1,0 +1,40 @@
+# no-inline-enums
+
+This rule validates that no `SchemaObject` with enum is located outside of `DefinitionsObject` for Swagger or `ComponentsObject` for OpenAPI.
+
+## Examples of valid and invalid OpenAPI SchemaObjects
+
+```yaml
+paths:
+    '/url':
+        get:
+            responses:
+                '200':
+                    content:
+                        'application/json':
+                            schema:
+                                type: 'string' # <-- invalid
+                                enum: ['foo', 'bar']
+components:
+    schemas:
+        Example:
+            type: 'string' # <-- valid
+            enum: ['foo', 'bar']
+```
+## Examples of valid and invalid Swagger SchemaObjects
+
+```yaml
+paths:
+    '/url':
+        get:
+            responses:
+                default:
+                    description: 'default response'
+                    schema:
+                        type: 'string' # <-- invalid
+                        enum: ['foo', 'bar']
+definitions:
+    Example:
+        type: 'string' # <-- valid
+        enum: ['foo', 'bar']
+```

--- a/src/rules/no-inline-enums/spec/index.spec.ts
+++ b/src/rules/no-inline-enums/spec/index.spec.ts
@@ -1,0 +1,127 @@
+import rule from '../';
+import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
+import {swaggerlint} from '../../../';
+import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+
+describe(`rule "${rule.name}"`, () => {
+    const config: SwaggerlintConfig = {
+        rules: {
+            [rule.name]: true,
+        },
+    };
+
+    describe('swagger', () => {
+        it('should NOT error for an empty swagger sample', () => {
+            const result = swaggerlint(getSwaggerObject({}), config);
+
+            expect(result).toEqual([]);
+        });
+
+        it('should error for a SchemaObject with "allOf" property containing a single item', () => {
+            const mod: Partial<Swagger.SwaggerObject> = {
+                paths: {
+                    '/url': {
+                        get: {
+                            responses: {
+                                default: {
+                                    description: 'default response',
+                                    schema: {
+                                        type: 'string',
+                                        enum: ['foo', 'bar'],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                definitions: {
+                    Example: {
+                        type: 'string',
+                        enum: ['foo', 'bar'],
+                    },
+                },
+            };
+            const modConfig = getSwaggerObject(mod);
+            const result = swaggerlint(modConfig, config);
+            const location = [
+                'paths',
+                '/url',
+                'get',
+                'responses',
+                'default',
+                'schema',
+            ];
+            const expected = [
+                {
+                    msg:
+                        'Inline enums are not allowed. Move this SchemaObject to DefinitionsObject',
+                    name: rule.name,
+                    location,
+                },
+            ];
+
+            expect(result).toEqual(expected);
+        });
+    });
+
+    describe('OpenAPI', () => {
+        it('should NOT error for an empty swagger sample', () => {
+            const result = swaggerlint(getOpenAPIObject({}), config);
+
+            expect(result).toEqual([]);
+        });
+
+        it('should error for a SchemaObject with "allOf" property containing a single item', () => {
+            const mod: Partial<OpenAPI.OpenAPIObject> = {
+                paths: {
+                    '/url': {
+                        get: {
+                            responses: {
+                                '200': {
+                                    content: {
+                                        'application/json': {
+                                            schema: {
+                                                type: 'string',
+                                                enum: ['foo', 'bar'],
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                components: {
+                    schemas: {
+                        Example: {
+                            type: 'string',
+                            enum: ['foo', 'bar'],
+                        },
+                    },
+                },
+            };
+            const modConfig = getOpenAPIObject(mod);
+            const result = swaggerlint(modConfig, config);
+            const location = [
+                'paths',
+                '/url',
+                'get',
+                'responses',
+                '200',
+                'content',
+                'application/json',
+                'schema',
+            ];
+            const expected = [
+                {
+                    msg:
+                        'Inline enums are not allowed. Move this SchemaObject to ComponentsObject',
+                    name: rule.name,
+                    location,
+                },
+            ];
+
+            expect(result).toEqual(expected);
+        });
+    });
+});


### PR DESCRIPTION
This PR addresses #32 and #36
Ie 2 new rules are added
- no-external-refs
- no-inline-enums