### PR TITLE
Add rule message ids

### DIFF
--- a/docs/how-to-test-a-rule.md
+++ b/docs/how-to-test-a-rule.md
@@ -1,0 +1,37 @@
+# How to test a rule
+
+To test a rule you should utilize a built-in utility called `RuleTester`. Make sure to run it inside your test files.
+
+```js
+// nodejs
+const {RuleTester} = require('swaggerlint');
+const rule = require('../my-custom-rule');
+
+// es modules / typescript
+import {RuleTester} from 'swaggerlint';
+import rule from '../my-custom-rule';
+
+const ruleTester = new RuleTester(rule);
+
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'test name', // will be displayed in the test report
+                schema: {}, // part of the swagger schema to be tested
+            },
+            // other test cases
+        ],
+        invalid: [
+            {
+                it: 'test name',
+                schema: {
+                    path: {/* ... */}
+                },
+                errors: [/* ... */], // list of expected errors
+            },
+            // other test cases
+        ]
+    }
+})
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export {swaggerlint} from './swaggerlint';
+export {RuleTester} from './ruleTester';
 export * from './types';

--- a/src/ruleTester.ts
+++ b/src/ruleTester.ts
@@ -28,49 +28,6 @@ type Item<T> = {
     invalid: InvalidSample<T>;
 };
 
-type Param = {
-    rule: SwaggerlintRule<string>;
-    swagger?: Item<Swagger.SwaggerObject>;
-    openapi?: Item<OpenAPI.OpenAPIObject>;
-};
-
-export function ruleTester({rule, swagger}: Param): void {
-    const defaultConfig = {
-        rules: {[rule.name]: true},
-    };
-    describe(`rule: "${rule.name}"`, () => {
-        if (swagger) {
-            describe('swagger', () => {
-                (swagger.valid || []).forEach(validSample => {
-                    it(validSample.it, () => {
-                        expect(
-                            swaggerlint(
-                                getSwaggerObject(validSample.schema),
-                                validSample.config || defaultConfig,
-                            ),
-                        ).toEqual([]);
-                    });
-                });
-
-                swagger.invalid.forEach(invalidSample => {
-                    it(invalidSample.it, () => {
-                        const result = swaggerlint(
-                            getSwaggerObject(invalidSample.schema),
-                            invalidSample.config || defaultConfig,
-                        );
-
-                        expect(result).toMatchObject(invalidSample.errors);
-                    });
-                });
-            });
-        }
-
-        // if (Boolean(openapi)) {
-        //     describe('openapi', () => {});
-        // }
-    });
-}
-
 export class RuleTester {
     rule: SwaggerlintRule<string>;
     defaultConfig: SwaggerlintConfig;

--- a/src/ruleTester.ts
+++ b/src/ruleTester.ts
@@ -1,0 +1,159 @@
+import * as assert from 'assert';
+import {swaggerlint} from './swaggerlint';
+import {getSwaggerObject, getOpenAPIObject} from './utils/tests';
+import {
+    Swagger,
+    OpenAPI,
+    SwaggerlintRule,
+    SwaggerlintConfig,
+    LintError,
+} from './types';
+
+type ValidSample<Schema> = {
+    it: string;
+    schema: Partial<Schema>;
+    config?: SwaggerlintConfig;
+}[];
+
+type InvalidSample<Schema> = {
+    it: string;
+    schema: Partial<Schema>;
+    config?: SwaggerlintConfig;
+    errors: Partial<LintError>[];
+}[];
+
+type Item<T> = {
+    valid: ValidSample<T>;
+    invalid: InvalidSample<T>;
+};
+
+type Param = {
+    rule: SwaggerlintRule<string>;
+    swagger?: Item<Swagger.SwaggerObject>;
+    openapi?: Item<OpenAPI.OpenAPIObject>;
+};
+
+export function ruleTester({rule, swagger}: Param): void {
+    const defaultConfig = {
+        rules: {[rule.name]: true},
+    };
+    describe(`rule: "${rule.name}"`, () => {
+        if (swagger) {
+            describe('swagger', () => {
+                (swagger.valid || []).forEach(validSample => {
+                    it(validSample.it, () => {
+                        expect(
+                            swaggerlint(
+                                getSwaggerObject(validSample.schema),
+                                validSample.config || defaultConfig,
+                            ),
+                        ).toEqual([]);
+                    });
+                });
+
+                swagger.invalid.forEach(invalidSample => {
+                    it(invalidSample.it, () => {
+                        const result = swaggerlint(
+                            getSwaggerObject(invalidSample.schema),
+                            invalidSample.config || defaultConfig,
+                        );
+
+                        expect(result).toMatchObject(invalidSample.errors);
+                    });
+                });
+            });
+        }
+
+        // if (Boolean(openapi)) {
+        //     describe('openapi', () => {});
+        // }
+    });
+}
+
+export class RuleTester {
+    rule: SwaggerlintRule<string>;
+    defaultConfig: SwaggerlintConfig;
+
+    constructor(rule: SwaggerlintRule<string>) {
+        this.rule = rule;
+        this.defaultConfig = {
+            rules: {
+                [rule.name]: true,
+            },
+        };
+    }
+
+    run({
+        swagger,
+        openapi,
+    }: {
+        swagger?: Item<Swagger.SwaggerObject>;
+        openapi?: Item<OpenAPI.OpenAPIObject>;
+    }) {
+        const {defaultConfig} = this;
+
+        function runTests(
+            sample: Item<Swagger.SwaggerObject>,
+            name: 'Swagger',
+        ): void;
+        function runTests(
+            sample: Item<OpenAPI.OpenAPIObject>,
+            name: 'OpenAPI',
+        ): void;
+        function runTests(
+            sample: Item<Swagger.SwaggerObject | OpenAPI.OpenAPIObject>,
+            name: 'Swagger' | 'OpenAPI',
+        ): void {
+            const makeSchema =
+                name === 'Swagger' ? getSwaggerObject : getOpenAPIObject;
+
+            describe(name, () => {
+                describe('valid', () => {
+                    sample.valid.forEach(valid => {
+                        it(valid.it, () => {
+                            expect(
+                                swaggerlint(
+                                    // @ts-expect-error: mom, typescript is merging arguments again
+                                    makeSchema(valid.schema),
+                                    valid.config || defaultConfig,
+                                ),
+                            ).toEqual([]);
+                        });
+                    });
+                });
+
+                describe('invalid', () => {
+                    sample.invalid.forEach(invalid => {
+                        it(invalid.it, () => {
+                            const actual = swaggerlint(
+                                // @ts-expect-error: mom, typescript is merging arguments again
+                                makeSchema(invalid.schema),
+                                invalid.config || defaultConfig,
+                            );
+                            const expected = invalid.errors;
+
+                            if (actual.length !== expected.length) {
+                                assert.fail(
+                                    `Expected ${expected.length} error${
+                                        expected.length === 1 ? '' : 's'
+                                    } but got ${actual.length}`,
+                                );
+                            }
+                            expect(actual).toMatchObject(expected);
+                        });
+                    });
+                });
+            });
+        }
+
+        describe(this.rule.name, () => {
+            if (swagger) runTests(swagger, 'Swagger');
+            if (openapi) runTests(openapi, 'OpenAPI');
+
+            if (!swagger && !openapi)
+                assert.fail(
+                    'Neither swagger nor openapi was passed to RuleTester',
+                );
+        });
+    }
+}

--- a/src/rules/expressive-path-summary/index.ts
+++ b/src/rules/expressive-path-summary/index.ts
@@ -1,34 +1,41 @@
-import {
-    SwaggerlintRule,
-    RuleVisitorFunction,
-    Swagger,
-    OpenAPI,
-} from '../../types';
+import {createRule} from '../../utils';
+import {RuleVisitorFunction, Swagger, OpenAPI} from '../../types';
 
 const name = 'expressive-path-summary';
+const messages = {
+    noSummary: 'Every path has to have a summary.',
+    nonExpressive: `Every path summary should contain at least 2 words. This has "{{summary}}"`,
+};
 const operationObjectValidator: RuleVisitorFunction<
-    OpenAPI.OperationObject | Swagger.OperationObject
+    OpenAPI.OperationObject | Swagger.OperationObject,
+    keyof typeof messages
 > = ({node, report, location}) => {
     const {summary} = node;
     if (typeof summary === 'string') {
         if (summary.split(' ').length < 2) {
-            report(
-                `Every path summary should contain at least 2 words. This has "${summary}"`,
-                [...location, 'summary'],
-            );
+            report({
+                messageId: 'nonExpressive',
+                data: {
+                    summary,
+                },
+                location: [...location, 'summary'],
+            });
         }
     } else {
-        report('Every path has to have a summary.');
+        report({messageId: 'noSummary'});
     }
 };
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages,
+    },
     swaggerVisitor: {
         OperationObject: operationObjectValidator,
     },
     openapiVisitor: {
         OperationObject: operationObjectValidator,
     },
-};
+});
 
 export default rule;

--- a/src/rules/expressive-path-summary/spec/index.spec.ts
+++ b/src/rules/expressive-path-summary/spec/index.spec.ts
@@ -1,233 +1,215 @@
 import rule from '../';
-import {Swagger, OpenAPI, SwaggerlintConfig} from '../../../types';
-import {swaggerlint} from '../../../';
+import {RuleTester} from '../../../';
 
-const swaggerSample: Swagger.SwaggerObject = {
-    swagger: '2.0',
-    info: {
-        title: 'stub',
-        version: '1.0',
+const ruleTester = new RuleTester(rule);
+
+ruleTester.run({
+    swagger: {
+        valid: [],
+        invalid: [
+            {
+                it: 'should error for missing and poor path summaries',
+                schema: {
+                    paths: {
+                        '/some/api/path': {
+                            get: {
+                                tags: ['random'],
+                                summary: 'upload-image',
+                                description: '',
+                                consumes: ['multipart/form-data'],
+                                produces: ['application/json'],
+                                responses: {
+                                    '200': {
+                                        description: 'successful operation',
+                                        schema: {
+                                            $ref: '#/definitions/ApiResponse',
+                                        },
+                                    },
+                                },
+                            },
+                            post: {
+                                tags: ['random'],
+                                description: '',
+                                consumes: ['multipart/form-data'],
+                                produces: ['application/json'],
+                                responses: {
+                                    '200': {
+                                        description: 'successful operation',
+                                        schema: {
+                                            $ref: '#/definitions/ApiResponse',
+                                        },
+                                    },
+                                },
+                            },
+                            delete: {
+                                tags: ['random'],
+                                summary: '',
+                                description: '',
+                                consumes: ['multipart/form-data'],
+                                produces: ['application/json'],
+                                responses: {
+                                    '200': {
+                                        description: 'successful operation',
+                                        schema: {
+                                            $ref: '#/definitions/ApiResponse',
+                                        },
+                                    },
+                                },
+                            },
+                            patch: {
+                                tags: ['random'],
+                                summary:
+                                    'wonderful summary, well described the meaning of this endpoint method.',
+                                description: '',
+                                consumes: ['multipart/form-data'],
+                                produces: ['application/json'],
+                                responses: {
+                                    '200': {
+                                        description: 'successful operation',
+                                        schema: {
+                                            $ref: '#/definitions/ApiResponse',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                errors: [
+                    {
+                        location: ['paths', '/some/api/path', 'get', 'summary'],
+                        msg:
+                            'Every path summary should contain at least 2 words. This has "upload-image"',
+                        messageId: 'nonExpressive',
+                        data: {
+                            summary: 'upload-image',
+                        },
+                    },
+                    {
+                        location: ['paths', '/some/api/path', 'post'],
+                        msg: 'Every path has to have a summary.',
+                        messageId: 'noSummary',
+                    },
+                    {
+                        location: [
+                            'paths',
+                            '/some/api/path',
+                            'delete',
+                            'summary',
+                        ],
+                        msg:
+                            'Every path summary should contain at least 2 words. This has ""',
+                        messageId: 'nonExpressive',
+                        data: {
+                            summary: '',
+                        },
+                    },
+                ],
+            },
+        ],
     },
-    paths: {
-        '/some/api/path': {
-            get: {
-                tags: ['random'],
-                summary: 'upload-image',
-                description: '',
-                consumes: ['multipart/form-data'],
-                produces: ['application/json'],
-                responses: {
-                    '200': {
-                        description: 'successful operation',
-                        schema: {
-                            $ref: '#/definitions/ApiResponse',
+    openapi: {
+        valid: [],
+        invalid: [
+            {
+                it: 'should error for missing and poor path summaries',
+                schema: {
+                    paths: {
+                        '/some/api/path': {
+                            get: {
+                                tags: ['random'],
+                                summary: 'upload-image',
+                                description: '',
+                                consumes: ['multipart/form-data'],
+                                produces: ['application/json'],
+                                responses: {
+                                    '200': {
+                                        description: 'successful operation',
+                                        schema: {
+                                            $ref: '#/definitions/ApiResponse',
+                                        },
+                                    },
+                                },
+                            },
+                            post: {
+                                tags: ['random'],
+                                description: '',
+                                consumes: ['multipart/form-data'],
+                                produces: ['application/json'],
+                                responses: {
+                                    '200': {
+                                        description: 'successful operation',
+                                        schema: {
+                                            $ref: '#/definitions/ApiResponse',
+                                        },
+                                    },
+                                },
+                            },
+                            delete: {
+                                tags: ['random'],
+                                summary: '',
+                                description: '',
+                                consumes: ['multipart/form-data'],
+                                produces: ['application/json'],
+                                responses: {
+                                    '200': {
+                                        description: 'successful operation',
+                                        schema: {
+                                            $ref: '#/definitions/ApiResponse',
+                                        },
+                                    },
+                                },
+                            },
+                            patch: {
+                                tags: ['random'],
+                                summary:
+                                    'wonderful summary, well described the meaning of this endpoint method.',
+                                description: '',
+                                consumes: ['multipart/form-data'],
+                                produces: ['application/json'],
+                                responses: {
+                                    '200': {
+                                        description: 'successful operation',
+                                        schema: {
+                                            $ref: '#/definitions/ApiResponse',
+                                        },
+                                    },
+                                },
+                            },
                         },
                     },
                 },
-            },
-            post: {
-                tags: ['random'],
-                description: '',
-                consumes: ['multipart/form-data'],
-                produces: ['application/json'],
-                responses: {
-                    '200': {
-                        description: 'successful operation',
-                        schema: {
-                            $ref: '#/definitions/ApiResponse',
+                errors: [
+                    {
+                        location: ['paths', '/some/api/path', 'get', 'summary'],
+                        msg:
+                            'Every path summary should contain at least 2 words. This has "upload-image"',
+                        messageId: 'nonExpressive',
+                        data: {
+                            summary: 'upload-image',
                         },
                     },
-                },
-            },
-            delete: {
-                tags: ['random'],
-                summary: '',
-                description: '',
-                consumes: ['multipart/form-data'],
-                produces: ['application/json'],
-                responses: {
-                    '200': {
-                        description: 'successful operation',
-                        schema: {
-                            $ref: '#/definitions/ApiResponse',
+                    {
+                        location: ['paths', '/some/api/path', 'post'],
+                        msg: 'Every path has to have a summary.',
+                        messageId: 'noSummary',
+                    },
+                    {
+                        location: [
+                            'paths',
+                            '/some/api/path',
+                            'delete',
+                            'summary',
+                        ],
+                        msg:
+                            'Every path summary should contain at least 2 words. This has ""',
+                        messageId: 'nonExpressive',
+                        data: {
+                            summary: '',
                         },
                     },
-                },
+                ],
             },
-            patch: {
-                tags: ['random'],
-                summary:
-                    'wonderful summary, well described the meaning of this endpoint method.',
-                description: '',
-                consumes: ['multipart/form-data'],
-                produces: ['application/json'],
-                responses: {
-                    '200': {
-                        description: 'successful operation',
-                        schema: {
-                            $ref: '#/definitions/ApiResponse',
-                        },
-                    },
-                },
-            },
-        },
+        ],
     },
-    tags: [],
-};
-
-const openapiSample: OpenAPI.OpenAPIObject = {
-    openapi: '3.0.3',
-    info: {
-        title: 'stub',
-        version: '1.0',
-    },
-    paths: {
-        '/some/api/path': {
-            get: {
-                tags: ['random'],
-                summary: 'upload-image',
-                description: '',
-                consumes: ['multipart/form-data'],
-                produces: ['application/json'],
-                responses: {
-                    '200': {
-                        description: 'successful operation',
-                        schema: {
-                            $ref: '#/definitions/ApiResponse',
-                        },
-                    },
-                },
-            },
-            post: {
-                tags: ['random'],
-                description: '',
-                consumes: ['multipart/form-data'],
-                produces: ['application/json'],
-                responses: {
-                    '200': {
-                        description: 'successful operation',
-                        schema: {
-                            $ref: '#/definitions/ApiResponse',
-                        },
-                    },
-                },
-            },
-            delete: {
-                tags: ['random'],
-                summary: '',
-                description: '',
-                consumes: ['multipart/form-data'],
-                produces: ['application/json'],
-                responses: {
-                    '200': {
-                        description: 'successful operation',
-                        schema: {
-                            $ref: '#/definitions/ApiResponse',
-                        },
-                    },
-                },
-            },
-            patch: {
-                tags: ['random'],
-                summary:
-                    'wonderful summary, well described the meaning of this endpoint method.',
-                description: '',
-                consumes: ['multipart/form-data'],
-                produces: ['application/json'],
-                responses: {
-                    '200': {
-                        description: 'successful operation',
-                        schema: {
-                            $ref: '#/definitions/ApiResponse',
-                        },
-                    },
-                },
-            },
-        },
-    },
-    tags: [],
-};
-
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: true,
-        },
-    };
-
-    describe('swagger', () => {
-        it('should error for missing and poor path summaries', () => {
-            const result = swaggerlint(swaggerSample, config);
-
-            const invalidSummary = {
-                location: ['paths', '/some/api/path', 'get', 'summary'],
-                msg:
-                    'Every path summary should contain at least 2 words. This has "upload-image"',
-                name: rule.name,
-                messageId: 'nonExpressive',
-                data: {
-                    summary: 'upload-image',
-                },
-            };
-            const emptySummary = {
-                location: ['paths', '/some/api/path', 'delete', 'summary'],
-                msg:
-                    'Every path summary should contain at least 2 words. This has ""',
-                messageId: 'nonExpressive',
-                data: {
-                    summary: '',
-                },
-                name: rule.name,
-            };
-            const missingSummary = {
-                location: ['paths', '/some/api/path', 'post'],
-                msg: 'Every path has to have a summary.',
-                messageId: 'noSummary',
-                name: rule.name,
-            };
-            expect(result).toEqual([
-                invalidSummary,
-                missingSummary,
-                emptySummary,
-            ]);
-        });
-    });
-
-    describe('openAPI', () => {
-        it('should error for missing and poor path summaries', () => {
-            const result = swaggerlint(openapiSample, config);
-
-            const invalidSummary = {
-                location: ['paths', '/some/api/path', 'get', 'summary'],
-                msg:
-                    'Every path summary should contain at least 2 words. This has "upload-image"',
-                messageId: 'nonExpressive',
-                data: {
-                    summary: 'upload-image',
-                },
-                name: rule.name,
-            };
-            const emptySummary = {
-                location: ['paths', '/some/api/path', 'delete', 'summary'],
-                msg:
-                    'Every path summary should contain at least 2 words. This has ""',
-                messageId: 'nonExpressive',
-                data: {
-                    summary: '',
-                },
-                name: rule.name,
-            };
-            const missingSummary = {
-                location: ['paths', '/some/api/path', 'post'],
-                msg: 'Every path has to have a summary.',
-                messageId: 'noSummary',
-                name: rule.name,
-            };
-            expect(result).toEqual([
-                invalidSummary,
-                missingSummary,
-                emptySummary,
-            ]);
-        });
-    });
 });

--- a/src/rules/expressive-path-summary/spec/index.spec.ts
+++ b/src/rules/expressive-path-summary/spec/index.spec.ts
@@ -164,16 +164,25 @@ describe(`rule "${rule.name}"`, () => {
                 msg:
                     'Every path summary should contain at least 2 words. This has "upload-image"',
                 name: rule.name,
+                messageId: 'nonExpressive',
+                data: {
+                    summary: 'upload-image',
+                },
             };
             const emptySummary = {
                 location: ['paths', '/some/api/path', 'delete', 'summary'],
                 msg:
                     'Every path summary should contain at least 2 words. This has ""',
+                messageId: 'nonExpressive',
+                data: {
+                    summary: '',
+                },
                 name: rule.name,
             };
             const missingSummary = {
                 location: ['paths', '/some/api/path', 'post'],
                 msg: 'Every path has to have a summary.',
+                messageId: 'noSummary',
                 name: rule.name,
             };
             expect(result).toEqual([
@@ -192,17 +201,26 @@ describe(`rule "${rule.name}"`, () => {
                 location: ['paths', '/some/api/path', 'get', 'summary'],
                 msg:
                     'Every path summary should contain at least 2 words. This has "upload-image"',
+                messageId: 'nonExpressive',
+                data: {
+                    summary: 'upload-image',
+                },
                 name: rule.name,
             };
             const emptySummary = {
                 location: ['paths', '/some/api/path', 'delete', 'summary'],
                 msg:
                     'Every path summary should contain at least 2 words. This has ""',
+                messageId: 'nonExpressive',
+                data: {
+                    summary: '',
+                },
                 name: rule.name,
             };
             const missingSummary = {
                 location: ['paths', '/some/api/path', 'post'],
                 msg: 'Every path has to have a summary.',
+                messageId: 'noSummary',
                 name: rule.name,
             };
             expect(result).toEqual([

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -15,7 +15,7 @@ import requiredTagDescription from './required-tag-description';
 
 import {SwaggerlintRule} from '../types';
 
-const rules: Record<string, SwaggerlintRule> = {
+const rules: Record<string, SwaggerlintRule<string>> = {
     [expressivePathSummary.name]: expressivePathSummary,
     [latinDefinitionsOnly.name]: latinDefinitionsOnly,
     [noEmptyObjectType.name]: noEmptyObjectType,

--- a/src/rules/latin-definitions-only/index.ts
+++ b/src/rules/latin-definitions-only/index.ts
@@ -1,5 +1,5 @@
-import {SwaggerlintRule} from '../../types';
 import {componentsKeys} from '../../utils/openapi';
+import {createRule} from '../../utils';
 
 const name = 'latin-definitions-only';
 
@@ -13,17 +13,25 @@ function hasNonLatinCharacters(str: string): boolean {
     );
 }
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            msg: `Definition name "{{name}}" contains non latin characters.`,
+        },
+    },
     swaggerVisitor: {
         DefinitionsObject: ({node, report, location}): void => {
             const definitionNames = Object.keys(node);
             definitionNames.forEach(name => {
                 if (hasNonLatinCharacters(name)) {
-                    report(
-                        `Definition name "${name}" contains non latin characters.`,
-                        [...location, name],
-                    );
+                    report({
+                        messageId: 'msg',
+                        data: {
+                            name,
+                        },
+                        location: [...location, name],
+                    });
                 }
             });
         },
@@ -35,15 +43,18 @@ const rule: SwaggerlintRule = {
                 if (val === undefined) return;
                 Object.keys(val).forEach(recName => {
                     if (hasNonLatinCharacters(recName)) {
-                        report(
-                            `Definition name "${recName}" contains non latin characters.`,
-                            [...location, compName, recName],
-                        );
+                        report({
+                            messageId: 'msg',
+                            data: {
+                                name: recName,
+                            },
+                            location: [...location, compName, recName],
+                        });
                     }
                 });
             });
         },
     },
-};
+});
 
 export default rule;

--- a/src/rules/latin-definitions-only/spec/index.spec.ts
+++ b/src/rules/latin-definitions-only/spec/index.spec.ts
@@ -1,86 +1,25 @@
 import rule from '../';
-import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../../';
 
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: true,
-        },
-    };
+const ruleTester = new RuleTester(rule);
 
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for all non latin named definitions', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                definitions: {
-                    valid: {
-                        type: 'object',
-                    },
-                    'invalid-obj': {
-                        type: 'object',
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {
+                    definitions: {
+                        foo: {},
+                        Foo: {},
+                        FOO: {},
                     },
                 },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = ['definitions', 'invalid-obj'];
-            const expected = [
-                {
-                    data: {
-                        name: 'invalid-obj',
-                    },
-                    messageId: 'msg',
-                    msg:
-                        'Definition name "invalid-obj" contains non latin characters.',
-                    name: rule.name,
-                    location,
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should not error for ignored definitions', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                definitions: {
-                    'invalid-obj': {
-                        type: 'object',
-                    },
-                },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, {
-                rules: {
-                    [rule.name]: true,
-                },
-                ignore: {
-                    definitions: ['invalid-obj'],
-                },
-            });
-            const expected = [] as [];
-
-            expect(result).toEqual(expected);
-        });
-    });
-
-    describe('openAPI', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for all non latin named definitions', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    schemas: {
+            },
+            {
+                it: 'should not error for ignored definitions',
+                schema: {
+                    definitions: {
                         valid: {
                             type: 'object',
                         },
@@ -89,30 +28,21 @@ describe(`rule "${rule.name}"`, () => {
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = ['components', 'schemas', 'invalid-obj'];
-            const expected = [
-                {
-                    data: {
-                        name: 'invalid-obj',
+                config: {
+                    rules: {
+                        [rule.name]: true,
                     },
-                    messageId: 'msg',
-                    msg:
-                        'Definition name "invalid-obj" contains non latin characters.',
-                    name: rule.name,
-                    location,
+                    ignore: {
+                        definitions: ['invalid-obj'],
+                    },
                 },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should not error for ignored definitions', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    schemas: {
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for all non latin named definitions',
+                schema: {
+                    definitions: {
                         valid: {
                             type: 'object',
                         },
@@ -121,31 +51,81 @@ describe(`rule "${rule.name}"`, () => {
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, {
-                rules: {
-                    [rule.name]: true,
-                },
-                ignore: {
+                errors: [
+                    {
+                        data: {
+                            name: 'invalid-obj',
+                        },
+                        messageId: 'msg',
+                        msg:
+                            'Definition name "invalid-obj" contains non latin characters.',
+                        name: rule.name,
+                        location: ['definitions', 'invalid-obj'],
+                    },
+                ],
+            },
+        ],
+    },
+    openapi: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+            {
+                it: 'should not error for ignored definitions',
+                schema: {
                     components: {
-                        schemas: ['invalid-obj'],
+                        schemas: {
+                            valid: {
+                                type: 'object',
+                            },
+                            'invalid-obj': {
+                                type: 'object',
+                            },
+                        },
                     },
                 },
-            });
-            const expected = [] as [];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should not error for empty components object', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {},
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-
-            expect(result).toEqual([]);
-        });
-    });
+                config: {
+                    rules: {
+                        [rule.name]: true,
+                    },
+                    ignore: {
+                        components: {
+                            schemas: ['invalid-obj'],
+                        },
+                    },
+                },
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for all non latin named definitions',
+                schema: {
+                    components: {
+                        schemas: {
+                            valid: {
+                                type: 'object',
+                            },
+                            'invalid-obj': {
+                                type: 'object',
+                            },
+                        },
+                    },
+                },
+                errors: [
+                    {
+                        data: {
+                            name: 'invalid-obj',
+                        },
+                        messageId: 'msg',
+                        msg:
+                            'Definition name "invalid-obj" contains non latin characters.',
+                        name: rule.name,
+                        location: ['components', 'schemas', 'invalid-obj'],
+                    },
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/latin-definitions-only/spec/index.spec.ts
+++ b/src/rules/latin-definitions-only/spec/index.spec.ts
@@ -33,6 +33,10 @@ describe(`rule "${rule.name}"`, () => {
             const location = ['definitions', 'invalid-obj'];
             const expected = [
                 {
+                    data: {
+                        name: 'invalid-obj',
+                    },
+                    messageId: 'msg',
                     msg:
                         'Definition name "invalid-obj" contains non latin characters.',
                     name: rule.name,
@@ -91,6 +95,10 @@ describe(`rule "${rule.name}"`, () => {
             const location = ['components', 'schemas', 'invalid-obj'];
             const expected = [
                 {
+                    data: {
+                        name: 'invalid-obj',
+                    },
+                    messageId: 'msg',
                     msg:
                         'Definition name "invalid-obj" contains non latin characters.',
                     name: rule.name,

--- a/src/rules/no-empty-object-type/index.ts
+++ b/src/rules/no-empty-object-type/index.ts
@@ -1,9 +1,15 @@
-import {SwaggerlintRule} from '../../types';
+import {createRule} from '../../utils';
 
 const name = 'no-empty-object-type';
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            swagger: `has "object" type but is missing "properties" | "additionalProperties" | "allOf"`,
+            openapi: `has "object" type but is missing "properties" | "additionalProperties" | "allOf" | "anyOf" | "oneOf"`,
+        },
+    },
     swaggerVisitor: {
         SchemaObject: ({node, report}): void => {
             if (node.type !== 'object') return;
@@ -15,9 +21,9 @@ const rule: SwaggerlintRule = {
 
             if (hasProperties || hasAllOf || hasAdditionalProperties) return;
 
-            report(
-                `has "object" type but is missing "properties" | "additionalProperties" | "allOf"`,
-            );
+            report({
+                messageId: 'swagger',
+            });
         },
     },
     openapiVisitor: {
@@ -40,11 +46,11 @@ const rule: SwaggerlintRule = {
             )
                 return;
 
-            report(
-                `has "object" type but is missing "properties" | "additionalProperties" | "allOf" | "anyOf" | "oneOf"`,
-            );
+            report({
+                messageId: 'openapi',
+            });
         },
     },
-};
+});
 
 export default rule;

--- a/src/rules/no-empty-object-type/spec/index.spec.ts
+++ b/src/rules/no-empty-object-type/spec/index.spec.ts
@@ -53,6 +53,7 @@ describe(`rule "${rule.name}"`, () => {
             const expected = [
                 {
                     msg: `has "object" type but is missing "properties" | "additionalProperties" | "allOf"`,
+                    messageId: 'swagger',
                     name: rule.name,
                     location,
                 },
@@ -135,6 +136,7 @@ describe(`rule "${rule.name}"`, () => {
             const expected = [
                 {
                     msg: `has "object" type but is missing "properties" | "additionalProperties" | "allOf" | "anyOf" | "oneOf"`,
+                    messageId: 'openapi',
                     name: rule.name,
                     location,
                 },

--- a/src/rules/no-empty-object-type/spec/index.spec.ts
+++ b/src/rules/no-empty-object-type/spec/index.spec.ts
@@ -1,79 +1,21 @@
 import rule from '../';
-import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../../';
 
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: true,
-        },
-    };
+const ruleTester = new RuleTester(rule);
 
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for empty object type', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                definitions: {
-                    InvalidDTO: {
-                        type: 'object',
-                    },
-                    ValidDTO: {
-                        type: 'object',
-                        additionalProperties: {
-                            type: 'string',
-                        },
-                        properties: {
-                            a: {
-                                type: 'string',
-                            },
-                            AllOf: {
-                                type: 'object',
-                                allOf: [
-                                    {
-                                        $ref: '#/components/schemas/InvalidDTO',
-                                    },
-                                    {
-                                        $ref: '#/components/schemas/ValidDTO',
-                                    },
-                                ],
-                            },
-                        },
-                    },
-                },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = ['definitions', 'InvalidDTO'];
-            const expected = [
-                {
-                    msg: `has "object" type but is missing "properties" | "additionalProperties" | "allOf"`,
-                    messageId: 'swagger',
-                    name: rule.name,
-                    location,
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
-
-    describe('OpenAPI', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for empty object type', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    schemas: {
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for empty object type',
+                schema: {
+                    definitions: {
                         InvalidDTO: {
                             type: 'object',
                         },
@@ -99,50 +41,99 @@ describe(`rule "${rule.name}"`, () => {
                                         },
                                     ],
                                 },
-                                OneOf: {
-                                    type: 'object',
-                                    oneOf: [
-                                        {
-                                            $ref:
-                                                '#/components/schemas/InvalidDTO',
-                                        },
-                                        {
-                                            $ref:
-                                                '#/components/schemas/ValidDTO',
-                                        },
-                                    ],
+                            },
+                        },
+                    },
+                },
+                errors: [
+                    {
+                        msg: `has "object" type but is missing "properties" | "additionalProperties" | "allOf"`,
+                        messageId: 'swagger',
+                        name: rule.name,
+                        location: ['definitions', 'InvalidDTO'],
+                    },
+                ],
+            },
+        ],
+    },
+    openapi: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for empty object type',
+                schema: {
+                    components: {
+                        schemas: {
+                            InvalidDTO: {
+                                type: 'object',
+                            },
+                            ValidDTO: {
+                                type: 'object',
+                                additionalProperties: {
+                                    type: 'string',
                                 },
-                                AnyOf: {
-                                    type: 'object',
-                                    anyOf: [
-                                        {
-                                            $ref:
-                                                '#/components/schemas/InvalidDTO',
-                                        },
-                                        {
-                                            $ref:
-                                                '#/components/schemas/ValidDTO',
-                                        },
-                                    ],
+                                properties: {
+                                    a: {
+                                        type: 'string',
+                                    },
+                                    AllOf: {
+                                        type: 'object',
+                                        allOf: [
+                                            {
+                                                $ref:
+                                                    '#/components/schemas/InvalidDTO',
+                                            },
+                                            {
+                                                $ref:
+                                                    '#/components/schemas/ValidDTO',
+                                            },
+                                        ],
+                                    },
+                                    OneOf: {
+                                        type: 'object',
+                                        oneOf: [
+                                            {
+                                                $ref:
+                                                    '#/components/schemas/InvalidDTO',
+                                            },
+                                            {
+                                                $ref:
+                                                    '#/components/schemas/ValidDTO',
+                                            },
+                                        ],
+                                    },
+                                    AnyOf: {
+                                        type: 'object',
+                                        anyOf: [
+                                            {
+                                                $ref:
+                                                    '#/components/schemas/InvalidDTO',
+                                            },
+                                            {
+                                                $ref:
+                                                    '#/components/schemas/ValidDTO',
+                                            },
+                                        ],
+                                    },
                                 },
                             },
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = ['components', 'schemas', 'InvalidDTO'];
-            const expected = [
-                {
-                    msg: `has "object" type but is missing "properties" | "additionalProperties" | "allOf" | "anyOf" | "oneOf"`,
-                    messageId: 'openapi',
-                    name: rule.name,
-                    location,
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
+                errors: [
+                    {
+                        msg: `has "object" type but is missing "properties" | "additionalProperties" | "allOf" | "anyOf" | "oneOf"`,
+                        messageId: 'openapi',
+                        name: rule.name,
+                        location: ['components', 'schemas', 'InvalidDTO'],
+                    },
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/no-external-refs/index.ts
+++ b/src/rules/no-external-refs/index.ts
@@ -1,16 +1,21 @@
-import {SwaggerlintRule} from '../../types';
+import {createRule} from '../../utils';
 
 const name = 'no-external-refs';
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            msg: 'External references are banned.',
+        },
+    },
     openapiVisitor: {
         ReferenceObject: ({node, report}): void => {
             if (!node.$ref.startsWith('#')) {
-                report('External references are banned.');
+                report({messageId: 'msg'});
             }
         },
     },
-};
+});
 
 export default rule;

--- a/src/rules/no-external-refs/spec/index.spec.ts
+++ b/src/rules/no-external-refs/spec/index.spec.ts
@@ -1,59 +1,51 @@
 import rule from '../';
-import {SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../../';
 
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: true,
-        },
-    };
+const ruleTester = new RuleTester(rule);
 
-    describe('OpenAPI', () => {
-        it('should NOT error for an empty openapi sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for an external reference object', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    schemas: {
-                        Example: {
-                            type: 'object',
-                            properties: {
-                                foo: {
-                                    $ref: '#/components/schemas/Foo',
-                                },
-                                bar: {
-                                    $ref: 'schemas.yaml#/Bar',
+ruleTester.run({
+    openapi: {
+        valid: [
+            {
+                it: 'should not error for an empty openapi sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for an external reference object',
+                schema: {
+                    components: {
+                        schemas: {
+                            Example: {
+                                type: 'object',
+                                properties: {
+                                    foo: {
+                                        $ref: '#/components/schemas/Foo',
+                                    },
+                                    bar: {
+                                        $ref: 'schemas.yaml#/Bar',
+                                    },
                                 },
                             },
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = [
-                'components',
-                'schemas',
-                'Example',
-                'properties',
-                'bar',
-            ];
-            const expected = [
-                {
-                    msg: 'External references are banned.',
-                    messageId: 'msg',
-                    name: rule.name,
-                    location,
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
+                errors: [
+                    {
+                        msg: 'External references are banned.',
+                        messageId: 'msg',
+                        name: rule.name,
+                        location: [
+                            'components',
+                            'schemas',
+                            'Example',
+                            'properties',
+                            'bar',
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/no-external-refs/spec/index.spec.ts
+++ b/src/rules/no-external-refs/spec/index.spec.ts
@@ -47,6 +47,7 @@ describe(`rule "${rule.name}"`, () => {
             const expected = [
                 {
                     msg: 'External references are banned.',
+                    messageId: 'msg',
                     name: rule.name,
                     location,
                 },

--- a/src/rules/no-inline-enums/index.ts
+++ b/src/rules/no-inline-enums/index.ts
@@ -1,27 +1,31 @@
-import {SwaggerlintRule} from '../../types';
+import {createRule} from '../../utils';
 
 const name = 'no-inline-enums';
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            swagger:
+                'Inline enums are not allowed. Move this SchemaObject to DefinitionsObject',
+            openapi:
+                'Inline enums are not allowed. Move this SchemaObject to ComponentsObject',
+        },
+    },
     swaggerVisitor: {
         SchemaObject: ({node, report, location}): void => {
             if (node.enum && location[0] !== 'definitions') {
-                report(
-                    'Inline enums are not allowed. Move this SchemaObject to DefinitionsObject',
-                );
+                report({messageId: 'swagger'});
             }
         },
     },
     openapiVisitor: {
         SchemaObject: ({node, report, location}): void => {
             if (node.enum && location[0] !== 'components') {
-                report(
-                    'Inline enums are not allowed. Move this SchemaObject to ComponentsObject',
-                );
+                report({messageId: 'openapi'});
             }
         },
     },
-};
+});
 
 export default rule;

--- a/src/rules/no-inline-enums/spec/index.spec.ts
+++ b/src/rules/no-inline-enums/spec/index.spec.ts
@@ -56,6 +56,7 @@ describe(`rule "${rule.name}"`, () => {
                     msg:
                         'Inline enums are not allowed. Move this SchemaObject to DefinitionsObject',
                     name: rule.name,
+                    messageId: 'swagger',
                     location,
                 },
             ];
@@ -117,6 +118,7 @@ describe(`rule "${rule.name}"`, () => {
                     msg:
                         'Inline enums are not allowed. Move this SchemaObject to ComponentsObject',
                     name: rule.name,
+                    messageId: 'openapi',
                     location,
                 },
             ];

--- a/src/rules/no-inline-enums/spec/index.spec.ts
+++ b/src/rules/no-inline-enums/spec/index.spec.ts
@@ -1,89 +1,83 @@
 import rule from '../';
-import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../../';
 
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: true,
-        },
-    };
+const ruleTester = new RuleTester(rule);
 
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a SchemaObject with "allOf" property containing a single item', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        type: 'string',
-                                        enum: ['foo', 'bar'],
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'errors for "allOf" property containing a single item',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            type: 'string',
+                                            enum: ['foo', 'bar'],
+                                        },
                                     },
                                 },
                             },
                         },
                     },
-                },
-                definitions: {
-                    Example: {
-                        type: 'string',
-                        enum: ['foo', 'bar'],
+                    definitions: {
+                        Example: {
+                            type: 'string',
+                            enum: ['foo', 'bar'],
+                        },
                     },
                 },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = [
-                'paths',
-                '/url',
-                'get',
-                'responses',
-                'default',
-                'schema',
-            ];
-            const expected = [
-                {
-                    msg:
-                        'Inline enums are not allowed. Move this SchemaObject to DefinitionsObject',
-                    name: rule.name,
-                    messageId: 'swagger',
-                    location,
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
-
-    describe('OpenAPI', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a SchemaObject with "allOf" property containing a single item', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                '200': {
-                                    content: {
-                                        'application/json': {
-                                            schema: {
-                                                type: 'string',
-                                                enum: ['foo', 'bar'],
+                errors: [
+                    {
+                        msg:
+                            'Inline enums are not allowed. Move this SchemaObject to DefinitionsObject',
+                        name: rule.name,
+                        messageId: 'swagger',
+                        location: [
+                            'paths',
+                            '/url',
+                            'get',
+                            'responses',
+                            'default',
+                            'schema',
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    openapi: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'errors for "allOf" property containing a single item',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    '200': {
+                                        content: {
+                                            'application/json': {
+                                                schema: {
+                                                    type: 'string',
+                                                    enum: ['foo', 'bar'],
+                                                },
                                             },
                                         },
                                     },
@@ -91,39 +85,34 @@ describe(`rule "${rule.name}"`, () => {
                             },
                         },
                     },
-                },
-                components: {
-                    schemas: {
-                        Example: {
-                            type: 'string',
-                            enum: ['foo', 'bar'],
+                    components: {
+                        schemas: {
+                            Example: {
+                                type: 'string',
+                                enum: ['foo', 'bar'],
+                            },
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = [
-                'paths',
-                '/url',
-                'get',
-                'responses',
-                '200',
-                'content',
-                'application/json',
-                'schema',
-            ];
-            const expected = [
-                {
-                    msg:
-                        'Inline enums are not allowed. Move this SchemaObject to ComponentsObject',
-                    name: rule.name,
-                    messageId: 'openapi',
-                    location,
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
+                errors: [
+                    {
+                        msg:
+                            'Inline enums are not allowed. Move this SchemaObject to ComponentsObject',
+                        name: rule.name,
+                        messageId: 'openapi',
+                        location: [
+                            'paths',
+                            '/url',
+                            'get',
+                            'responses',
+                            '200',
+                            'content',
+                            'application/json',
+                            'schema',
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/no-single-allof/index.ts
+++ b/src/rules/no-single-allof/index.ts
@@ -1,24 +1,28 @@
-import {SwaggerlintRule} from '../../types';
+import {createRule} from '../../utils';
 
 const name = 'no-single-allof';
-const msg = 'Redundant use of "allOf" with a single item in it.';
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            msg: 'Redundant use of "allOf" with a single item in it.',
+        },
+    },
     swaggerVisitor: {
         SchemaObject: ({node, report, location}): void => {
             if ('allOf' in node && node.allOf.length === 1) {
-                report(msg, [...location, 'allOf']);
+                report({messageId: 'msg', location: [...location, 'allOf']});
             }
         },
     },
     openapiVisitor: {
         SchemaObject: ({node, report, location}): void => {
             if (node.allOf && node.allOf.length === 1) {
-                report(msg, [...location, 'allOf']);
+                report({messageId: 'msg', location: [...location, 'allOf']});
             }
         },
     },
-};
+});
 
 export default rule;

--- a/src/rules/no-single-allof/spec/index.spec.ts
+++ b/src/rules/no-single-allof/spec/index.spec.ts
@@ -1,134 +1,71 @@
 import rule from '../';
-import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../..';
 
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: true,
-        },
-    };
+const ruleTester = new RuleTester(rule);
 
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a SchemaObject with "allOf" property containing a single item', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/Example',
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'should not error for an empty swagger sample',
+                schema: {},
+            },
+            {
+                it: 'should not error for the "allOf" with multiple items',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/Example',
+                                        },
                                     },
                                 },
                             },
                         },
                     },
-                },
-                definitions: {
-                    Example: {
-                        type: 'object',
-                        allOf: [
-                            {
-                                type: 'object',
-                                properties: {
-                                    prop: {type: 'string'},
-                                    anotherProp: {type: 'string'},
+                    definitions: {
+                        Example: {
+                            type: 'object',
+                            allOf: [
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        prop: {type: 'string'},
+                                        anotherProp: {type: 'string'},
+                                    },
                                 },
-                            },
-                        ],
+                                {
+                                    type: 'object',
+                                },
+                            ],
+                        },
                     },
                 },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = ['definitions', 'Example', 'allOf'];
-            const expected = [
-                {
-                    messageId: 'msg',
-                    msg: 'Redundant use of "allOf" with a single item in it.',
-                    name: rule.name,
-                    location,
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should NOT error for a SchemaObject with "allOf" property containing multiple items', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/Example',
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for "allOf" with a single item',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/Example',
+                                        },
                                     },
                                 },
                             },
                         },
                     },
-                },
-                definitions: {
-                    Example: {
-                        type: 'object',
-                        allOf: [
-                            {
-                                type: 'object',
-                                properties: {
-                                    prop: {type: 'string'},
-                                    anotherProp: {type: 'string'},
-                                },
-                            },
-                            {
-                                type: 'object',
-                            },
-                        ],
-                    },
-                },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-
-            expect(result).toEqual([]);
-        });
-    });
-
-    describe('OpenAPI', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a SchemaObject with "allOf" property containing a single item', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/Example',
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-                components: {
-                    schemas: {
+                    definitions: {
                         Example: {
                             type: 'object',
                             allOf: [
@@ -143,60 +80,106 @@ describe(`rule "${rule.name}"`, () => {
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = ['components', 'schemas', 'Example', 'allOf'];
-            const expected = [
-                {
-                    msg: 'Redundant use of "allOf" with a single item in it.',
-                    messageId: 'msg',
-                    name: rule.name,
-                    location,
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should NOT error for a SchemaObject with "allOf" property containing multiple items', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/Example',
+                errors: [
+                    {
+                        messageId: 'msg',
+                        msg:
+                            'Redundant use of "allOf" with a single item in it.',
+                        name: rule.name,
+                        location: ['definitions', 'Example', 'allOf'],
+                    },
+                ],
+            },
+        ],
+    },
+    openapi: {
+        valid: [
+            {
+                it: 'does not error for an empty swagger sample',
+                schema: {},
+            },
+            {
+                it: 'does not error for "allOf" property with multiple items',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/Example',
+                                        },
                                     },
                                 },
                             },
                         },
                     },
-                },
-                definitions: {
-                    Example: {
-                        type: 'object',
-                        allOf: [
-                            {
-                                type: 'object',
-                                properties: {
-                                    prop: {type: 'string'},
-                                    anotherProp: {type: 'string'},
+                    definitions: {
+                        Example: {
+                            type: 'object',
+                            allOf: [
+                                {
+                                    type: 'object',
+                                    properties: {
+                                        prop: {type: 'string'},
+                                        anotherProp: {type: 'string'},
+                                    },
                                 },
-                            },
-                            {
-                                type: 'object',
-                            },
-                        ],
+                                {
+                                    type: 'object',
+                                },
+                            ],
+                        },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-
-            expect(result).toEqual([]);
-        });
-    });
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for "allOf" property with a single item',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/Example',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    components: {
+                        schemas: {
+                            Example: {
+                                type: 'object',
+                                allOf: [
+                                    {
+                                        type: 'object',
+                                        properties: {
+                                            prop: {type: 'string'},
+                                            anotherProp: {type: 'string'},
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+                errors: [
+                    {
+                        msg:
+                            'Redundant use of "allOf" with a single item in it.',
+                        messageId: 'msg',
+                        name: rule.name,
+                        location: ['components', 'schemas', 'Example', 'allOf'],
+                    },
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/no-single-allof/spec/index.spec.ts
+++ b/src/rules/no-single-allof/spec/index.spec.ts
@@ -53,6 +53,7 @@ describe(`rule "${rule.name}"`, () => {
             const location = ['definitions', 'Example', 'allOf'];
             const expected = [
                 {
+                    messageId: 'msg',
                     msg: 'Redundant use of "allOf" with a single item in it.',
                     name: rule.name,
                     location,
@@ -149,6 +150,7 @@ describe(`rule "${rule.name}"`, () => {
             const expected = [
                 {
                     msg: 'Redundant use of "allOf" with a single item in it.',
+                    messageId: 'msg',
                     name: rule.name,
                     location,
                 },

--- a/src/rules/no-trailing-slash/index.ts
+++ b/src/rules/no-trailing-slash/index.ts
@@ -1,19 +1,29 @@
-import {SwaggerlintRule} from '../../types';
+import {createRule} from '../../utils';
 
 const name = 'no-trailing-slash';
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            url: 'Url cannot end with a slash "{{url}}".',
+            host: 'Host cannot end with a slash, your host url is "{{url}}".',
+            server: 'Server url cannot end with a slash "{{url}}".',
+        },
+    },
     swaggerVisitor: {
         PathsObject: ({node, report, location}): void => {
             const urls = Object.keys(node);
 
             urls.forEach(url => {
                 if (url.endsWith('/')) {
-                    report(`Url cannot end with a slash "${url}".`, [
-                        ...location,
-                        url,
-                    ]);
+                    report({
+                        messageId: 'url',
+                        data: {
+                            url,
+                        },
+                        location: [...location, url],
+                    });
                 }
             });
         },
@@ -21,7 +31,7 @@ const rule: SwaggerlintRule = {
             const {host} = node;
 
             if (typeof host === 'string' && host.endsWith('/')) {
-                report('Host url cannot end with a slash.', ['host']);
+                report({messageId: 'host', data: {host}, location: ['host']});
             }
         },
     },
@@ -30,18 +40,24 @@ const rule: SwaggerlintRule = {
             const url = location[location.length - 1];
 
             if (url.endsWith('/')) {
-                report(`Url cannot end with a slash "${url}".`);
+                report({
+                    messageId: 'url',
+                    data: {
+                        url,
+                    },
+                });
             }
         },
         ServerObject: ({node, report, location}): void => {
             if (node.url.endsWith('/')) {
-                report('Server url cannot end with a slash.', [
-                    ...location,
-                    'url',
-                ]);
+                report({
+                    messageId: 'server',
+                    data: {url: node.url},
+                    location: [...location, 'url'],
+                });
             }
         },
     },
-};
+});
 
 export default rule;

--- a/src/rules/no-trailing-slash/index.ts
+++ b/src/rules/no-trailing-slash/index.ts
@@ -31,7 +31,11 @@ const rule = createRule({
             const {host} = node;
 
             if (typeof host === 'string' && host.endsWith('/')) {
-                report({messageId: 'host', data: {host}, location: ['host']});
+                report({
+                    messageId: 'host',
+                    data: {url: host},
+                    location: ['host'],
+                });
             }
         },
     },

--- a/src/rules/no-trailing-slash/spec/index.spec.ts
+++ b/src/rules/no-trailing-slash/spec/index.spec.ts
@@ -51,6 +51,10 @@ describe(`rule "${rule.name}"`, () => {
             const result = swaggerlint(modConfig, config);
             const expected = [
                 {
+                    data: {
+                        url: '/url/',
+                    },
+                    messageId: 'url',
                     msg: 'Url cannot end with a slash "/url/".',
                     name: 'no-trailing-slash',
                     location: ['paths', '/url/'],
@@ -68,7 +72,12 @@ describe(`rule "${rule.name}"`, () => {
             const result = swaggerlint(modConfig, config);
             const expected = [
                 {
-                    msg: 'Host url cannot end with a slash.',
+                    data: {
+                        url: 'http://some.url/',
+                    },
+                    msg:
+                        'Host cannot end with a slash, your host url is "http://some.url/".',
+                    messageId: 'host',
                     name: 'no-trailing-slash',
                     location: ['host'],
                 },
@@ -90,6 +99,10 @@ describe(`rule "${rule.name}"`, () => {
             const result = swaggerlint(modConfig, config);
             const expected = [
                 {
+                    data: {
+                        url: '/url/',
+                    },
+                    messageId: 'url',
                     msg: 'Url cannot end with a slash "/url/".',
                     name: 'no-trailing-slash',
                     location: ['paths', '/url/'],
@@ -99,7 +112,7 @@ describe(`rule "${rule.name}"`, () => {
             expect(result).toEqual(expected);
         });
 
-        it('should error for a host url ending with a slash', () => {
+        it('should error for a server url ending with a slash', () => {
             const mod = {
                 servers: [{url: 'http://some.url/'}],
             };
@@ -107,7 +120,12 @@ describe(`rule "${rule.name}"`, () => {
             const result = swaggerlint(modConfig, config);
             const expected = [
                 {
-                    msg: 'Server url cannot end with a slash.',
+                    data: {
+                        url: 'http://some.url/',
+                    },
+                    msg:
+                        'Server url cannot end with a slash "http://some.url/".',
+                    messageId: 'server',
                     name: 'no-trailing-slash',
                     location: ['servers', '0', 'url'],
                 },

--- a/src/rules/no-trailing-slash/spec/index.spec.ts
+++ b/src/rules/no-trailing-slash/spec/index.spec.ts
@@ -1,137 +1,147 @@
 import rule from '../';
-import {SwaggerlintConfig} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../../';
 
-// eslint-disable-next-line
-const pathsWithSlashes: any = {
-    paths: {
-        '/url/': {
-            get: {
-                responses: {
-                    default: {
-                        description: 'default response',
-                        schema: {
-                            type: 'string',
+const ruleTester = new RuleTester(rule);
+
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for a url ending with a slash',
+                schema: {
+                    paths: {
+                        '/url/': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            type: 'string',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        '/correct-url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            type: 'string',
+                                        },
+                                    },
+                                },
+                            },
                         },
                     },
                 },
-            },
-        },
-        '/correct-url': {
-            get: {
-                responses: {
-                    default: {
-                        description: 'default response',
-                        schema: {
-                            type: 'string',
+                errors: [
+                    {
+                        data: {
+                            url: '/url/',
                         },
+                        messageId: 'url',
+                        msg: 'Url cannot end with a slash "/url/".',
+                        name: 'no-trailing-slash',
+                        location: ['paths', '/url/'],
                     },
-                },
+                ],
             },
-        },
+            {
+                it: 'should error for a host url ending with a slash',
+                schema: {
+                    host: 'http://some.url/',
+                },
+                errors: [
+                    {
+                        data: {
+                            url: 'http://some.url/',
+                        },
+                        msg:
+                            'Host cannot end with a slash, your host url is "http://some.url/".',
+                        messageId: 'host',
+                        name: 'no-trailing-slash',
+                        location: ['host'],
+                    },
+                ],
+            },
+        ],
     },
-};
-
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: true,
-        },
-    };
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a url ending with a slash', () => {
-            const modConfig = getSwaggerObject(pathsWithSlashes);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    data: {
-                        url: '/url/',
+    openapi: {
+        valid: [
+            {
+                it: 'should not error for an empty schema',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for a url ending with a slash',
+                schema: {
+                    paths: {
+                        '/url/': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            type: 'string',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        '/correct-url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            type: 'string',
+                                        },
+                                    },
+                                },
+                            },
+                        },
                     },
-                    messageId: 'url',
-                    msg: 'Url cannot end with a slash "/url/".',
-                    name: 'no-trailing-slash',
-                    location: ['paths', '/url/'],
                 },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should error for a host url ending with a slash', () => {
-            const mod = {
-                host: 'http://some.url/',
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    data: {
-                        url: 'http://some.url/',
+                errors: [
+                    {
+                        data: {
+                            url: '/url/',
+                        },
+                        messageId: 'url',
+                        msg: 'Url cannot end with a slash "/url/".',
+                        name: 'no-trailing-slash',
+                        location: ['paths', '/url/'],
                     },
-                    msg:
-                        'Host cannot end with a slash, your host url is "http://some.url/".',
-                    messageId: 'host',
-                    name: 'no-trailing-slash',
-                    location: ['host'],
+                ],
+            },
+            {
+                it: 'should error for a server url ending with a slash',
+                schema: {
+                    servers: [{url: 'http://some.url/'}],
                 },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
-
-    describe('OpenAPI', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a url ending with a slash', () => {
-            const modConfig = getOpenAPIObject(pathsWithSlashes);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    data: {
-                        url: '/url/',
+                errors: [
+                    {
+                        data: {
+                            url: 'http://some.url/',
+                        },
+                        msg:
+                            'Server url cannot end with a slash "http://some.url/".',
+                        messageId: 'server',
+                        name: 'no-trailing-slash',
+                        location: ['servers', '0', 'url'],
                     },
-                    messageId: 'url',
-                    msg: 'Url cannot end with a slash "/url/".',
-                    name: 'no-trailing-slash',
-                    location: ['paths', '/url/'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should error for a server url ending with a slash', () => {
-            const mod = {
-                servers: [{url: 'http://some.url/'}],
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    data: {
-                        url: 'http://some.url/',
-                    },
-                    msg:
-                        'Server url cannot end with a slash "http://some.url/".',
-                    messageId: 'server',
-                    name: 'no-trailing-slash',
-                    location: ['servers', '0', 'url'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/object-prop-casing/index.ts
+++ b/src/rules/object-prop-casing/index.ts
@@ -1,11 +1,17 @@
 import Case from 'case';
-import {SwaggerlintRule} from '../../types';
+import {createRule} from '../../utils';
 import {validCases, isValidCaseName, isObject} from '../../utils';
 
 const name = 'object-prop-casing';
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            casing:
+                'Property "{{propName}}" has wrong casing. Should be "{{correctVersion}}".',
+        },
+    },
     swaggerVisitor: {
         SchemaObject: ({node, report, setting, location}): void => {
             if (typeof setting === 'boolean') return;
@@ -29,10 +35,14 @@ const rule: SwaggerlintRule = {
                                 propName,
                             );
 
-                            report(
-                                `Property "${propName}" has wrong casing. Should be "${correctVersion}".`,
-                                [...location, 'properties', propName],
-                            );
+                            report({
+                                messageId: 'casing',
+                                data: {
+                                    propName,
+                                    correctVersion,
+                                },
+                                location: [...location, 'properties', propName],
+                            });
                         }
                     });
                 }
@@ -70,10 +80,14 @@ const rule: SwaggerlintRule = {
                             propName,
                         );
 
-                        report(
-                            `Property "${propName}" has wrong casing. Should be "${correctVersion}".`,
-                            [...location, 'properties', propName],
-                        );
+                        report({
+                            messageId: 'casing',
+                            data: {
+                                propName,
+                                correctVersion,
+                            },
+                            location: [...location, 'properties', propName],
+                        });
                     }
                 });
             }
@@ -102,6 +116,6 @@ const rule: SwaggerlintRule = {
         } else return false;
     },
     defaultSetting: ['camel'],
-};
+});
 
 export default rule;

--- a/src/rules/object-prop-casing/spec/index.spec.ts
+++ b/src/rules/object-prop-casing/spec/index.spec.ts
@@ -54,7 +54,6 @@ ruleTester.run({
                             type: 'object',
                             properties: {
                                 'some-casing': {type: 'string'},
-                                // eslint-disable-next-line
                                 some_casing: {type: 'string'},
                                 SOME_CASING: {type: 'string'},
                                 SomeCasing: {type: 'string'},
@@ -163,7 +162,6 @@ ruleTester.run({
                         messageId: 'casing',
                         msg:
                             'Property "some-casing" has wrong casing. Should be "someCasing".',
-                        name: 'object-prop-casing',
                         location: [
                             'definitions',
                             'lolkekDTO',
@@ -178,7 +176,7 @@ ruleTester.run({
     openapi: {
         valid: [
             {
-                it: 'should NOT error for an empty swagger sample',
+                it: 'should NOT error for an empty openapi sample',
                 schema: {},
             },
             {
@@ -226,7 +224,6 @@ ruleTester.run({
                             propName: 'some-casing',
                         },
                         messageId: 'casing',
-                        name: 'object-prop-casing',
                         location: [
                             'components',
                             'schemas',
@@ -241,7 +238,6 @@ ruleTester.run({
                             propName: 'some_casing',
                         },
                         messageId: 'casing',
-                        name: 'object-prop-casing',
                         location: [
                             'components',
                             'schemas',
@@ -256,7 +252,6 @@ ruleTester.run({
                             propName: 'SOME_CASING',
                         },
                         messageId: 'casing',
-                        name: 'object-prop-casing',
                         location: [
                             'components',
                             'schemas',
@@ -271,7 +266,6 @@ ruleTester.run({
                             propName: 'SomeCasing',
                         },
                         messageId: 'casing',
-                        name: 'object-prop-casing',
                         location: [
                             'components',
                             'schemas',
@@ -315,7 +309,6 @@ ruleTester.run({
                         messageId: 'casing',
                         msg:
                             'Property "some-casing" has wrong casing. Should be "someCasing".',
-                        name: 'object-prop-casing',
                         location: [
                             'components',
                             'schemas',

--- a/src/rules/object-prop-casing/spec/index.spec.ts
+++ b/src/rules/object-prop-casing/spec/index.spec.ts
@@ -52,24 +52,44 @@ describe(`rule "${rule.name}"`, () => {
             const location = ['definitions', 'lolkekDTO', 'properties'];
             const expected = [
                 {
+                    data: {
+                        correctVersion: 'someCasing',
+                        propName: 'some-casing',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Property "some-casing" has wrong casing. Should be "someCasing".',
                     name: 'object-prop-casing',
                     location: [...location, 'some-casing'],
                 },
                 {
+                    data: {
+                        correctVersion: 'someCasing',
+                        propName: 'some_casing',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Property "some_casing" has wrong casing. Should be "someCasing".',
                     name: 'object-prop-casing',
                     location: [...location, 'some_casing'],
                 },
                 {
+                    data: {
+                        correctVersion: 'someCasing',
+                        propName: 'SOME_CASING',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Property "SOME_CASING" has wrong casing. Should be "someCasing".',
                     name: 'object-prop-casing',
                     location: [...location, 'SOME_CASING'],
                 },
                 {
+                    data: {
+                        correctVersion: 'someCasing',
+                        propName: 'SomeCasing',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Property "SomeCasing" has wrong casing. Should be "someCasing".',
                     name: 'object-prop-casing',
@@ -124,6 +144,11 @@ describe(`rule "${rule.name}"`, () => {
             ];
             const expected = [
                 {
+                    data: {
+                        correctVersion: 'someCasing',
+                        propName: 'some-casing',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Property "some-casing" has wrong casing. Should be "someCasing".',
                     name: 'object-prop-casing',
@@ -189,24 +214,44 @@ describe(`rule "${rule.name}"`, () => {
             ];
             const expected = [
                 {
+                    data: {
+                        correctVersion: 'someCasing',
+                        propName: 'some-casing',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Property "some-casing" has wrong casing. Should be "someCasing".',
                     name: 'object-prop-casing',
                     location: [...location, 'some-casing'],
                 },
                 {
+                    data: {
+                        correctVersion: 'someCasing',
+                        propName: 'some_casing',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Property "some_casing" has wrong casing. Should be "someCasing".',
                     name: 'object-prop-casing',
                     location: [...location, 'some_casing'],
                 },
                 {
+                    data: {
+                        correctVersion: 'someCasing',
+                        propName: 'SOME_CASING',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Property "SOME_CASING" has wrong casing. Should be "someCasing".',
                     name: 'object-prop-casing',
                     location: [...location, 'SOME_CASING'],
                 },
                 {
+                    data: {
+                        correctVersion: 'someCasing',
+                        propName: 'SomeCasing',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Property "SomeCasing" has wrong casing. Should be "someCasing".',
                     name: 'object-prop-casing',
@@ -250,6 +295,11 @@ describe(`rule "${rule.name}"`, () => {
             ];
             const expected = [
                 {
+                    data: {
+                        correctVersion: 'someCasing',
+                        propName: 'some-casing',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Property "some-casing" has wrong casing. Should be "someCasing".',
                     name: 'object-prop-casing',

--- a/src/rules/object-prop-casing/spec/index.spec.ts
+++ b/src/rules/object-prop-casing/spec/index.spec.ts
@@ -1,195 +1,55 @@
 import rule from '../';
-import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../../ruleTester';
 
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: ['camel'],
-        },
-    };
+const ruleTester = new RuleTester(rule);
 
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for all non camel cased property names', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/lolkekDTO',
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'does not error for empty schema',
+                schema: {},
+                config: {
+                    rules: {
+                        [rule.name]: true,
+                    },
+                },
+            },
+            {
+                it: 'should NOT error for all non camel cased property names',
+                schema: {
+                    definitions: {
+                        lolkekDTO: {
+                            type: 'object',
+                            properties: {
+                                prop: {type: 'string'},
+                                anotherProp: {type: 'string'},
+                                yetAnotherProp: {type: 'string'},
+                            },
+                        },
+                    },
+                },
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for all non camel cased property names',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/lolkekDTO',
+                                        },
                                     },
                                 },
                             },
                         },
                     },
-                },
-                definitions: {
-                    lolkekDTO: {
-                        type: 'object',
-                        properties: {
-                            'some-casing': {type: 'string'},
-                            // eslint-disable-next-line
-                            some_casing: {type: 'string'},
-                            SOME_CASING: {type: 'string'},
-                            SomeCasing: {type: 'string'},
-                            someCasing: {type: 'string'},
-                        },
-                    },
-                },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = ['definitions', 'lolkekDTO', 'properties'];
-            const expected = [
-                {
-                    data: {
-                        correctVersion: 'someCasing',
-                        propName: 'some-casing',
-                    },
-                    messageId: 'casing',
-                    msg:
-                        'Property "some-casing" has wrong casing. Should be "someCasing".',
-                    name: 'object-prop-casing',
-                    location: [...location, 'some-casing'],
-                },
-                {
-                    data: {
-                        correctVersion: 'someCasing',
-                        propName: 'some_casing',
-                    },
-                    messageId: 'casing',
-                    msg:
-                        'Property "some_casing" has wrong casing. Should be "someCasing".',
-                    name: 'object-prop-casing',
-                    location: [...location, 'some_casing'],
-                },
-                {
-                    data: {
-                        correctVersion: 'someCasing',
-                        propName: 'SOME_CASING',
-                    },
-                    messageId: 'casing',
-                    msg:
-                        'Property "SOME_CASING" has wrong casing. Should be "someCasing".',
-                    name: 'object-prop-casing',
-                    location: [...location, 'SOME_CASING'],
-                },
-                {
-                    data: {
-                        correctVersion: 'someCasing',
-                        propName: 'SomeCasing',
-                    },
-                    messageId: 'casing',
-                    msg:
-                        'Property "SomeCasing" has wrong casing. Should be "someCasing".',
-                    name: 'object-prop-casing',
-                    location: [...location, 'SomeCasing'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should not error for ignored property names', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/lolkekDTO',
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-                definitions: {
-                    lolkekDTO: {
-                        type: 'object',
-                        properties: {
-                            'some-casing': {type: 'string'},
-                            SOME_CASING: {type: 'string'},
-                            SomeCasing: {type: 'string'},
-                        },
-                    },
-                },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, {
-                rules: {
-                    [rule.name]: [
-                        'camel',
-                        {ignore: ['SOME_CASING', 'SomeCasing']},
-                    ],
-                },
-            });
-            const location = [
-                'definitions',
-                'lolkekDTO',
-                'properties',
-                'some-casing',
-            ];
-            const expected = [
-                {
-                    data: {
-                        correctVersion: 'someCasing',
-                        propName: 'some-casing',
-                    },
-                    messageId: 'casing',
-                    msg:
-                        'Property "some-casing" has wrong casing. Should be "someCasing".',
-                    name: 'object-prop-casing',
-                    location,
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should NOT error for all non camel cased property names', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                definitions: {
-                    lolkekDTO: {
-                        type: 'object',
-                        properties: {
-                            prop: {type: 'string'},
-                            anotherProp: {type: 'string'},
-                            yetAnotherProp: {type: 'string'},
-                        },
-                    },
-                },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-
-            expect(result).toEqual([]);
-        });
-    });
-
-    describe('openapi', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for all non camel cased property names', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    schemas: {
+                    definitions: {
                         lolkekDTO: {
                             type: 'object',
                             properties: {
@@ -203,69 +63,79 @@ describe(`rule "${rule.name}"`, () => {
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const location = [
-                'components',
-                'schemas',
-                'lolkekDTO',
-                'properties',
-            ];
-            const expected = [
-                {
-                    data: {
-                        correctVersion: 'someCasing',
-                        propName: 'some-casing',
+                errors: [
+                    {
+                        data: {
+                            correctVersion: 'someCasing',
+                            propName: 'some-casing',
+                        },
+                        messageId: 'casing',
+                        location: [
+                            'definitions',
+                            'lolkekDTO',
+                            'properties',
+                            'some-casing',
+                        ],
                     },
-                    messageId: 'casing',
-                    msg:
-                        'Property "some-casing" has wrong casing. Should be "someCasing".',
-                    name: 'object-prop-casing',
-                    location: [...location, 'some-casing'],
-                },
-                {
-                    data: {
-                        correctVersion: 'someCasing',
-                        propName: 'some_casing',
+                    {
+                        data: {
+                            correctVersion: 'someCasing',
+                            propName: 'some_casing',
+                        },
+                        messageId: 'casing',
+                        location: [
+                            'definitions',
+                            'lolkekDTO',
+                            'properties',
+                            'some_casing',
+                        ],
                     },
-                    messageId: 'casing',
-                    msg:
-                        'Property "some_casing" has wrong casing. Should be "someCasing".',
-                    name: 'object-prop-casing',
-                    location: [...location, 'some_casing'],
-                },
-                {
-                    data: {
-                        correctVersion: 'someCasing',
-                        propName: 'SOME_CASING',
+                    {
+                        data: {
+                            correctVersion: 'someCasing',
+                            propName: 'SOME_CASING',
+                        },
+                        messageId: 'casing',
+                        location: [
+                            'definitions',
+                            'lolkekDTO',
+                            'properties',
+                            'SOME_CASING',
+                        ],
                     },
-                    messageId: 'casing',
-                    msg:
-                        'Property "SOME_CASING" has wrong casing. Should be "someCasing".',
-                    name: 'object-prop-casing',
-                    location: [...location, 'SOME_CASING'],
-                },
-                {
-                    data: {
-                        correctVersion: 'someCasing',
-                        propName: 'SomeCasing',
+                    {
+                        data: {
+                            correctVersion: 'someCasing',
+                            propName: 'SomeCasing',
+                        },
+                        messageId: 'casing',
+                        location: [
+                            'definitions',
+                            'lolkekDTO',
+                            'properties',
+                            'SomeCasing',
+                        ],
                     },
-                    messageId: 'casing',
-                    msg:
-                        'Property "SomeCasing" has wrong casing. Should be "someCasing".',
-                    name: 'object-prop-casing',
-                    location: [...location, 'SomeCasing'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should not error for ignored property names', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    schemas: {
+                ],
+            },
+            {
+                it: 'should not error for ignored property names',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/lolkekDTO',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    definitions: {
                         lolkekDTO: {
                             type: 'object',
                             properties: {
@@ -276,59 +146,186 @@ describe(`rule "${rule.name}"`, () => {
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, {
-                rules: {
-                    [rule.name]: [
-                        'camel',
-                        {ignore: ['SOME_CASING', 'SomeCasing']},
-                    ],
-                },
-            });
-            const location = [
-                'components',
-                'schemas',
-                'lolkekDTO',
-                'properties',
-                'some-casing',
-            ];
-            const expected = [
-                {
-                    data: {
-                        correctVersion: 'someCasing',
-                        propName: 'some-casing',
+                config: {
+                    rules: {
+                        [rule.name]: [
+                            'camel',
+                            {ignore: ['SOME_CASING', 'SomeCasing']},
+                        ],
                     },
-                    messageId: 'casing',
-                    msg:
-                        'Property "some-casing" has wrong casing. Should be "someCasing".',
-                    name: 'object-prop-casing',
-                    location,
                 },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should NOT error for all non camel cased property names', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    schemas: {
-                        lolkekDTO: {
-                            type: 'object',
-                            properties: {
-                                prop: {type: 'string'},
-                                anotherProp: {type: 'string'},
-                                yetAnotherProp: {type: 'string'},
+                errors: [
+                    {
+                        data: {
+                            correctVersion: 'someCasing',
+                            propName: 'some-casing',
+                        },
+                        messageId: 'casing',
+                        msg:
+                            'Property "some-casing" has wrong casing. Should be "someCasing".',
+                        name: 'object-prop-casing',
+                        location: [
+                            'definitions',
+                            'lolkekDTO',
+                            'properties',
+                            'some-casing',
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    openapi: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+            {
+                it: 'should NOT error for all non camel cased property names',
+                schema: {
+                    components: {
+                        schemas: {
+                            lolkekDTO: {
+                                type: 'object',
+                                properties: {
+                                    prop: {type: 'string'},
+                                    anotherProp: {type: 'string'},
+                                    yetAnotherProp: {type: 'string'},
+                                },
                             },
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-
-            expect(result).toEqual([]);
-        });
-    });
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for all non camel cased property names',
+                schema: {
+                    components: {
+                        schemas: {
+                            lolkekDTO: {
+                                type: 'object',
+                                properties: {
+                                    'some-casing': {type: 'string'},
+                                    // eslint-disable-next-line
+                                    some_casing: {type: 'string'},
+                                    SOME_CASING: {type: 'string'},
+                                    SomeCasing: {type: 'string'},
+                                    someCasing: {type: 'string'},
+                                },
+                            },
+                        },
+                    },
+                },
+                errors: [
+                    {
+                        data: {
+                            correctVersion: 'someCasing',
+                            propName: 'some-casing',
+                        },
+                        messageId: 'casing',
+                        name: 'object-prop-casing',
+                        location: [
+                            'components',
+                            'schemas',
+                            'lolkekDTO',
+                            'properties',
+                            'some-casing',
+                        ],
+                    },
+                    {
+                        data: {
+                            correctVersion: 'someCasing',
+                            propName: 'some_casing',
+                        },
+                        messageId: 'casing',
+                        name: 'object-prop-casing',
+                        location: [
+                            'components',
+                            'schemas',
+                            'lolkekDTO',
+                            'properties',
+                            'some_casing',
+                        ],
+                    },
+                    {
+                        data: {
+                            correctVersion: 'someCasing',
+                            propName: 'SOME_CASING',
+                        },
+                        messageId: 'casing',
+                        name: 'object-prop-casing',
+                        location: [
+                            'components',
+                            'schemas',
+                            'lolkekDTO',
+                            'properties',
+                            'SOME_CASING',
+                        ],
+                    },
+                    {
+                        data: {
+                            correctVersion: 'someCasing',
+                            propName: 'SomeCasing',
+                        },
+                        messageId: 'casing',
+                        name: 'object-prop-casing',
+                        location: [
+                            'components',
+                            'schemas',
+                            'lolkekDTO',
+                            'properties',
+                            'SomeCasing',
+                        ],
+                    },
+                ],
+            },
+            {
+                it: 'should not error for ignored property names',
+                schema: {
+                    components: {
+                        schemas: {
+                            lolkekDTO: {
+                                type: 'object',
+                                properties: {
+                                    'some-casing': {type: 'string'},
+                                    SOME_CASING: {type: 'string'},
+                                    SomeCasing: {type: 'string'},
+                                },
+                            },
+                        },
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: [
+                            'camel',
+                            {ignore: ['SOME_CASING', 'SomeCasing']},
+                        ],
+                    },
+                },
+                errors: [
+                    {
+                        data: {
+                            correctVersion: 'someCasing',
+                            propName: 'some-casing',
+                        },
+                        messageId: 'casing',
+                        msg:
+                            'Property "some-casing" has wrong casing. Should be "someCasing".',
+                        name: 'object-prop-casing',
+                        location: [
+                            'components',
+                            'schemas',
+                            'lolkekDTO',
+                            'properties',
+                            'some-casing',
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/only-valid-mime-types/index.ts
+++ b/src/rules/only-valid-mime-types/index.ts
@@ -47,7 +47,7 @@ const rule = createRule({
     name,
     meta: {
         messages: {
-            invalid: '"{{mimeType}}" is not a vlid mime type.',
+            invalid: '"{{mimeType}}" is not a valid mime type.',
         },
     },
     swaggerVisitor: {

--- a/src/rules/only-valid-mime-types/index.ts
+++ b/src/rules/only-valid-mime-types/index.ts
@@ -3,6 +3,9 @@ import {createRule} from '../../utils';
 import mimeDB from 'mime-db';
 
 const name = 'only-valid-mime-types';
+const messages = {
+    invalid: '"{{mimeType}}" is not a valid mime type.',
+};
 
 function isValidMimeType(maybeMime: string): boolean {
     return maybeMime in mimeDB;
@@ -10,7 +13,7 @@ function isValidMimeType(maybeMime: string): boolean {
 
 type Param = {
     node: Swagger.SwaggerObject | Swagger.OperationObject;
-    report: Report<'invalid'>;
+    report: Report<keyof typeof messages>;
     location: string[];
 };
 function onlyValidMimeTypeCheck({node, report, location}: Param): void {
@@ -45,11 +48,7 @@ function onlyValidMimeTypeCheck({node, report, location}: Param): void {
 
 const rule = createRule({
     name,
-    meta: {
-        messages: {
-            invalid: '"{{mimeType}}" is not a valid mime type.',
-        },
-    },
+    meta: {messages},
     swaggerVisitor: {
         SwaggerObject: onlyValidMimeTypeCheck,
         OperationObject: onlyValidMimeTypeCheck,

--- a/src/rules/only-valid-mime-types/index.ts
+++ b/src/rules/only-valid-mime-types/index.ts
@@ -1,4 +1,5 @@
-import {SwaggerlintRule, Report, Swagger} from '../../types';
+import {Report, Swagger} from '../../types';
+import {createRule} from '../../utils';
 import mimeDB from 'mime-db';
 
 const name = 'only-valid-mime-types';
@@ -9,7 +10,7 @@ function isValidMimeType(maybeMime: string): boolean {
 
 type Param = {
     node: Swagger.SwaggerObject | Swagger.OperationObject;
-    report: Report;
+    report: Report<'invalid'>;
     location: string[];
 };
 function onlyValidMimeTypeCheck({node, report, location}: Param): void {
@@ -17,29 +18,38 @@ function onlyValidMimeTypeCheck({node, report, location}: Param): void {
     if (consumes) {
         consumes.forEach((mType, i) => {
             if (!isValidMimeType(mType)) {
-                report(`"${mType}" is not a valid mime type.`, [
-                    ...location,
-                    'consumes',
-                    String(i),
-                ]);
+                report({
+                    messageId: 'invalid',
+                    data: {
+                        mimeType: mType,
+                    },
+                    location: [...location, 'consumes', String(i)],
+                });
             }
         });
     }
     if (produces) {
         produces.forEach((mType, i) => {
             if (!isValidMimeType(mType)) {
-                report(`"${mType}" is not a valid mime type.`, [
-                    ...location,
-                    'produces',
-                    String(i),
-                ]);
+                report({
+                    messageId: 'invalid',
+                    data: {
+                        mimeType: mType,
+                    },
+                    location: [...location, 'produces', String(i)],
+                });
             }
         });
     }
 }
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            invalid: '"{{mimeType}}" is not a vlid mime type.',
+        },
+    },
     swaggerVisitor: {
         SwaggerObject: onlyValidMimeTypeCheck,
         OperationObject: onlyValidMimeTypeCheck,
@@ -48,10 +58,15 @@ const rule: SwaggerlintRule = {
         MediaTypeObject: ({location, report}): void => {
             const mimeType = location[location.length - 1];
             if (!isValidMimeType(mimeType)) {
-                report(`"${mimeType}" is not a valid mime type.`);
+                report({
+                    messageId: 'invalid',
+                    data: {
+                        mimeType,
+                    },
+                });
             }
         },
     },
-};
+});
 
 export default rule;

--- a/src/rules/only-valid-mime-types/spec/index.spec.ts
+++ b/src/rules/only-valid-mime-types/spec/index.spec.ts
@@ -61,21 +61,37 @@ describe(`rule "${rule.name}"`, () => {
             const result = swaggerlint(modConfig, config);
             const expected = [
                 {
+                    data: {
+                        mimeType: 'lol/kek',
+                    },
+                    messageId: 'invalid',
                     msg: '"lol/kek" is not a valid mime type.',
                     name: rule.name,
                     location: ['consumes', '0'],
                 },
                 {
+                    data: {
+                        mimeType: 'application/typescript',
+                    },
                     msg: '"application/typescript" is not a valid mime type.',
+                    messageId: 'invalid',
                     name: rule.name,
                     location: ['produces', '0'],
                 },
                 {
+                    data: {
+                        mimeType: 'not/valid',
+                    },
+                    messageId: 'invalid',
                     msg: '"not/valid" is not a valid mime type.',
                     name: rule.name,
                     location: ['paths', '/url', 'get', 'consumes', '0'],
                 },
                 {
+                    data: {
+                        mimeType: '*/*',
+                    },
+                    messageId: 'invalid',
                     msg: '"*/*" is not a valid mime type.',
                     name: rule.name,
                     location: ['paths', '/url', 'get', 'produces', '0'],
@@ -113,6 +129,10 @@ describe(`rule "${rule.name}"`, () => {
             const result = swaggerlint(modConfig, config);
             const expected = [
                 {
+                    data: {
+                        mimeType: 'application/foo',
+                    },
+                    messageId: 'invalid',
                     msg: '"application/foo" is not a valid mime type.',
                     name: rule.name,
                     location: [

--- a/src/rules/only-valid-mime-types/spec/index.spec.ts
+++ b/src/rules/only-valid-mime-types/spec/index.spec.ts
@@ -1,151 +1,119 @@
 import rule from '../';
-import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject} from '../../../utils/tests';
+import {RuleTester} from '../../../ruleTester';
 
-const swaggerSample: Swagger.SwaggerObject = {
-    swagger: '2.0',
-    info: {
-        title: 'stub',
-        version: '1.0',
-    },
-    paths: {},
-    tags: [],
-};
+const ruleTester = new RuleTester(rule);
 
-const openapiSample: OpenAPI.OpenAPIObject = {
-    openapi: '3.0.3',
-    info: {
-        title: 'stub',
-        version: '1.0',
-    },
-    paths: {},
-    tags: [],
-};
-
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: ['camel'],
-        },
-    };
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(swaggerSample, config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for all non camel cased property names', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/lolkekDTO',
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for all non camel cased property names',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/lolkekDTO',
+                                        },
                                     },
                                 },
+                                consumes: ['not/valid'],
+                                produces: ['*/*'],
                             },
-                            consumes: ['not/valid'],
-                            produces: ['*/*'],
                         },
                     },
+                    produces: ['application/typescript'],
+                    consumes: ['lol/kek'],
                 },
-                produces: ['application/typescript'],
-                consumes: ['lol/kek'],
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    data: {
-                        mimeType: 'lol/kek',
+                errors: [
+                    {
+                        data: {
+                            mimeType: 'lol/kek',
+                        },
+                        messageId: 'invalid',
+                        msg: '"lol/kek" is not a valid mime type.',
+                        location: ['consumes', '0'],
                     },
-                    messageId: 'invalid',
-                    msg: '"lol/kek" is not a valid mime type.',
-                    name: rule.name,
-                    location: ['consumes', '0'],
-                },
-                {
-                    data: {
-                        mimeType: 'application/typescript',
+                    {
+                        data: {
+                            mimeType: 'application/typescript',
+                        },
+                        msg:
+                            '"application/typescript" is not a valid mime type.',
+                        messageId: 'invalid',
+                        location: ['produces', '0'],
                     },
-                    msg: '"application/typescript" is not a valid mime type.',
-                    messageId: 'invalid',
-                    name: rule.name,
-                    location: ['produces', '0'],
-                },
-                {
-                    data: {
-                        mimeType: 'not/valid',
+                    {
+                        data: {
+                            mimeType: 'not/valid',
+                        },
+                        messageId: 'invalid',
+                        msg: '"not/valid" is not a valid mime type.',
+                        location: ['paths', '/url', 'get', 'consumes', '0'],
                     },
-                    messageId: 'invalid',
-                    msg: '"not/valid" is not a valid mime type.',
-                    name: rule.name,
-                    location: ['paths', '/url', 'get', 'consumes', '0'],
-                },
-                {
-                    data: {
-                        mimeType: '*/*',
+                    {
+                        data: {
+                            mimeType: '*/*',
+                        },
+                        messageId: 'invalid',
+                        msg: '"*/*" is not a valid mime type.',
+                        location: ['paths', '/url', 'get', 'produces', '0'],
                     },
-                    messageId: 'invalid',
-                    msg: '"*/*" is not a valid mime type.',
-                    name: rule.name,
-                    location: ['paths', '/url', 'get', 'produces', '0'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
-
-    describe('openAPI', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(openapiSample, config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for all non camel cased property names', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    responses: {
-                        someReponse: {
-                            content: {
-                                'application/foo': {
-                                    schema: {
-                                        $ref: '#/components/schemas/resp',
+                ],
+            },
+        ],
+    },
+    openapi: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for all non camel cased property names',
+                schema: {
+                    components: {
+                        responses: {
+                            someReponse: {
+                                content: {
+                                    'application/foo': {
+                                        schema: {
+                                            $ref: '#/components/schemas/resp',
+                                        },
                                     },
                                 },
                             },
                         },
                     },
                 },
-            };
-            const modConfig = {...openapiSample, ...mod};
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    data: {
-                        mimeType: 'application/foo',
+                errors: [
+                    {
+                        data: {
+                            mimeType: 'application/foo',
+                        },
+                        messageId: 'invalid',
+                        msg: '"application/foo" is not a valid mime type.',
+                        location: [
+                            'components',
+                            'responses',
+                            'someReponse',
+                            'content',
+                            'application/foo',
+                        ],
                     },
-                    messageId: 'invalid',
-                    msg: '"application/foo" is not a valid mime type.',
-                    name: rule.name,
-                    location: [
-                        'components',
-                        'responses',
-                        'someReponse',
-                        'content',
-                        'application/foo',
-                    ],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/parameter-casing/index.ts
+++ b/src/rules/parameter-casing/index.ts
@@ -1,6 +1,12 @@
 import Case from 'case';
-import {SwaggerlintRule, CaseName, Swagger, OpenAPI} from '../../types';
-import {validCases, isValidCaseName, isObject, hasKey} from '../../utils';
+import {CaseName, Swagger, OpenAPI} from '../../types';
+import {
+    createRule,
+    hasKey,
+    isObject,
+    isValidCaseName,
+    validCases,
+} from '../../utils';
 
 const name = 'parameter-casing';
 
@@ -25,8 +31,14 @@ const PARAMETER_LOCATIONS: (
     'body',
 ];
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            casing:
+                'Parameter "{{name}}" has wrong casing. Should be "{{correctVersion}}".',
+        },
+    },
     swaggerVisitor: {
         ParameterObject: ({node, report, location, setting}): void => {
             if (typeof setting === 'boolean') return;
@@ -66,10 +78,14 @@ const rule: SwaggerlintRule = {
 
                     const correctVersion = Case[shouldBeCase](node.name);
 
-                    report(
-                        `Parameter "${node.name}" has wrong casing. Should be "${correctVersion}".`,
-                        [...location, 'name'],
-                    );
+                    report({
+                        messageId: 'casing',
+                        data: {
+                            name: node.name,
+                            correctVersion,
+                        },
+                        location: [...location, 'name'],
+                    });
                 }
             }
         },
@@ -111,10 +127,14 @@ const rule: SwaggerlintRule = {
 
                     const correctVersion = Case[shouldBeCase](node.name);
 
-                    report(
-                        `Parameter "${node.name}" has wrong casing. Should be "${correctVersion}".`,
-                        [...location, 'name'],
-                    );
+                    report({
+                        messageId: 'casing',
+                        data: {
+                            name: node.name,
+                            correctVersion,
+                        },
+                        location: [...location, 'name'],
+                    });
                 }
             }
         },
@@ -156,6 +176,6 @@ const rule: SwaggerlintRule = {
         } else return false;
     },
     defaultSetting: ['camel', {header: 'kebab'}],
-};
+});
 
 export default rule;

--- a/src/rules/parameter-casing/spec/index.spec.ts
+++ b/src/rules/parameter-casing/spec/index.spec.ts
@@ -1,475 +1,459 @@
 import rule from '../';
-import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../..';
 
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: ['camel'],
-        },
-    };
+const ruleTester = new RuleTester(rule);
 
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for all non camel cased property names', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/lolkekDTO',
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+            {
+                it:
+                    'allows to set different casing for different parameters(in)',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/lolkekDTO',
+                                        },
                                     },
                                 },
                             },
+                            parameters: [
+                                {
+                                    name: 'pet-type',
+                                    in: 'path',
+                                    required: true,
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'petStore',
+                                    in: 'body',
+                                    type: 'string',
+                                    schema: {
+                                        $ref: '',
+                                    },
+                                },
+                                {
+                                    name: 'pet_color',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                            ],
                         },
-                        parameters: [
-                            {
-                                name: 'petType',
-                                in: 'query',
-                                type: 'string',
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: ['camel', {query: 'snake', path: 'kebab'}],
+                    },
+                },
+            },
+            {
+                it: 'allows to ignore parameter names',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/lolkekDTO',
+                                        },
+                                    },
+                                },
                             },
-                            {
-                                name: 'PET_STORE',
-                                in: 'query',
-                                type: 'string',
-                            },
-                            {
-                                name: 'pet-age',
-                                in: 'query',
-                                type: 'string',
-                            },
-                            {
-                                name: 'pet_color',
-                                in: 'query',
-                                type: 'string',
-                            },
+                            parameters: [
+                                {
+                                    name: 'pet-type',
+                                    in: 'path',
+                                    required: true,
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'petStore',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'pet_color',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                            ],
+                        },
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: [
+                            'camel',
+                            {ignore: ['pet-type', 'pet_color']},
                         ],
                     },
                 },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    data: {
-                        correctVersion: 'petStore',
-                        name: 'PET_STORE',
-                    },
-                    messageId: 'casing',
-                    msg:
-                        'Parameter "PET_STORE" has wrong casing. Should be "petStore".',
-                    name: 'parameter-casing',
-                    location: ['paths', '/url', 'parameters', '1', 'name'],
-                },
-                {
-                    data: {
-                        correctVersion: 'petAge',
-                        name: 'pet-age',
-                    },
-                    messageId: 'casing',
-                    msg:
-                        'Parameter "pet-age" has wrong casing. Should be "petAge".',
-                    name: 'parameter-casing',
-                    location: ['paths', '/url', 'parameters', '2', 'name'],
-                },
-                {
-                    data: {
-                        correctVersion: 'petColor',
-                        name: 'pet_color',
-                    },
-                    messageId: 'casing',
-                    msg:
-                        'Parameter "pet_color" has wrong casing. Should be "petColor".',
-                    name: 'parameter-casing',
-                    location: ['paths', '/url', 'parameters', '3', 'name'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should not error for all ignored property names', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/lolkekDTO',
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for all non camel cased property names',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/lolkekDTO',
+                                        },
                                     },
                                 },
                             },
+                            parameters: [
+                                {
+                                    name: 'petType',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'PET_STORE',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'pet-age',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'pet_color',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                            ],
                         },
-                        parameters: [
-                            {
-                                name: 'petType',
-                                in: 'query',
-                                type: 'string',
+                    },
+                },
+                errors: [
+                    {
+                        data: {
+                            correctVersion: 'petStore',
+                            name: 'PET_STORE',
+                        },
+                        messageId: 'casing',
+                        msg:
+                            'Parameter "PET_STORE" has wrong casing. Should be "petStore".',
+                        location: ['paths', '/url', 'parameters', '1', 'name'],
+                    },
+                    {
+                        data: {
+                            correctVersion: 'petAge',
+                            name: 'pet-age',
+                        },
+                        messageId: 'casing',
+                        msg:
+                            'Parameter "pet-age" has wrong casing. Should be "petAge".',
+                        location: ['paths', '/url', 'parameters', '2', 'name'],
+                    },
+                    {
+                        data: {
+                            correctVersion: 'petColor',
+                            name: 'pet_color',
+                        },
+                        messageId: 'casing',
+                        msg:
+                            'Parameter "pet_color" has wrong casing. Should be "petColor".',
+                        location: ['paths', '/url', 'parameters', '3', 'name'],
+                    },
+                ],
+            },
+            {
+                it: 'should not error for all ignored property names',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/lolkekDTO',
+                                        },
+                                    },
+                                },
                             },
-                            {
-                                name: 'PET_STORE',
-                                in: 'query',
-                                type: 'string',
-                            },
-                            {
-                                name: 'pet-age',
-                                in: 'query',
-                                type: 'string',
-                            },
-                            {
-                                name: 'pet_color',
-                                in: 'query',
-                                type: 'string',
-                            },
+                            parameters: [
+                                {
+                                    name: 'petType',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'PET_STORE',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'pet-age',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'pet_color',
+                                    in: 'query',
+                                    type: 'string',
+                                },
+                            ],
+                        },
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: [
+                            'camel',
+                            {ignore: ['PET_STORE', 'pet-age']},
                         ],
                     },
                 },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, {
-                rules: {
-                    [rule.name]: ['camel', {ignore: ['PET_STORE', 'pet-age']}],
-                },
-            });
-            const expected = [
-                {
-                    data: {
-                        correctVersion: 'petColor',
-                        name: 'pet_color',
-                    },
-                    messageId: 'casing',
-                    msg:
-                        'Parameter "pet_color" has wrong casing. Should be "petColor".',
-                    name: 'parameter-casing',
-                    location: ['paths', '/url', 'parameters', '3', 'name'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('allows to set different casing for different parameters(in)', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/lolkekDTO',
-                                    },
-                                },
-                            },
+                errors: [
+                    {
+                        data: {
+                            correctVersion: 'petColor',
+                            name: 'pet_color',
                         },
-                        parameters: [
-                            {
+                        messageId: 'casing',
+                        msg:
+                            'Parameter "pet_color" has wrong casing. Should be "petColor".',
+                        name: 'parameter-casing',
+                        location: ['paths', '/url', 'parameters', '3', 'name'],
+                    },
+                ],
+            },
+        ],
+    },
+    openapi: {
+        valid: [
+            {
+                it: 'should NOT error for an empty openapi sample',
+                schema: {},
+            },
+            {
+                it:
+                    'allows to set different casing for different parameters(in)',
+                schema: {
+                    components: {
+                        parameters: {
+                            foo: {
                                 name: 'pet-type',
                                 in: 'path',
                                 required: true,
-                                type: 'string',
-                            },
-                            {
-                                name: 'petStore',
-                                in: 'body',
-                                type: 'string',
                                 schema: {
-                                    $ref: '',
+                                    type: 'string',
                                 },
                             },
-                            {
+                            bar: {
+                                name: 'petStore',
+                                in: 'cookie',
+                                schema: {
+                                    type: 'string',
+                                },
+                            },
+                            baz: {
                                 name: 'pet_color',
                                 in: 'query',
-                                type: 'string',
-                            },
-                        ],
-                    },
-                },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, {
-                rules: {
-                    [rule.name]: ['camel', {query: 'snake', path: 'kebab'}],
-                },
-            });
-
-            expect(result).toEqual([]);
-        });
-
-        it('allows to ignore parameter names', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/lolkekDTO',
-                                    },
+                                schema: {
+                                    type: 'string',
                                 },
                             },
                         },
-                        parameters: [
-                            {
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: ['camel', {query: 'snake', path: 'kebab'}],
+                    },
+                },
+            },
+            {
+                it: 'allows to ignore parameter names',
+                schema: {
+                    components: {
+                        parameters: {
+                            foo: {
                                 name: 'pet-type',
                                 in: 'path',
                                 required: true,
-                                type: 'string',
+                                schema: {
+                                    type: 'string',
+                                },
                             },
-                            {
+                            bar: {
                                 name: 'petStore',
-                                in: 'query',
-                                type: 'string',
+                                in: 'cookie',
+                                schema: {
+                                    type: 'string',
+                                },
                             },
-                            {
+                            baz: {
                                 name: 'pet_color',
                                 in: 'query',
-                                type: 'string',
+                                schema: {
+                                    type: 'string',
+                                },
                             },
+                        },
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: [
+                            'camel',
+                            {ignore: ['pet-type', 'pet_color']},
                         ],
                     },
                 },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, {
-                rules: {
-                    [rule.name]: ['camel', {ignore: ['pet-type', 'pet_color']}],
-                },
-            });
-
-            expect(result).toEqual([]);
-        });
-    });
-
-    describe('openapi', () => {
-        it('should NOT error for an empty openapi sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for all non camel cased property names', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    parameters: {
-                        foo: {
-                            name: 'petType',
-                            in: 'query',
-                            schema: {
-                                type: 'string',
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for all non camel cased property names',
+                schema: {
+                    components: {
+                        parameters: {
+                            foo: {
+                                name: 'petType',
+                                in: 'query',
+                                schema: {
+                                    type: 'string',
+                                },
+                            },
+                            bar: {
+                                name: 'PET_STORE',
+                                in: 'query',
+                                schema: {
+                                    type: 'string',
+                                },
+                            },
+                            baz: {
+                                name: 'pet-age',
+                                in: 'query',
+                                schema: {
+                                    type: 'string',
+                                },
+                            },
+                            zoo: {
+                                name: 'pet_color',
+                                in: 'query',
+                                schema: {
+                                    type: 'string',
+                                },
                             },
                         },
-                        bar: {
+                    },
+                },
+                errors: [
+                    {
+                        msg:
+                            'Parameter "PET_STORE" has wrong casing. Should be "petStore".',
+                        data: {
+                            correctVersion: 'petStore',
                             name: 'PET_STORE',
-                            in: 'query',
-                            schema: {
-                                type: 'string',
-                            },
                         },
-                        baz: {
+                        messageId: 'casing',
+                        name: 'parameter-casing',
+                        location: ['components', 'parameters', 'bar', 'name'],
+                    },
+                    {
+                        msg:
+                            'Parameter "pet-age" has wrong casing. Should be "petAge".',
+                        data: {
+                            correctVersion: 'petAge',
                             name: 'pet-age',
-                            in: 'query',
-                            schema: {
-                                type: 'string',
-                            },
                         },
-                        zoo: {
+                        messageId: 'casing',
+                        name: 'parameter-casing',
+                        location: ['components', 'parameters', 'baz', 'name'],
+                    },
+                    {
+                        data: {
+                            correctVersion: 'petColor',
                             name: 'pet_color',
-                            in: 'query',
-                            schema: {
-                                type: 'string',
+                        },
+                        messageId: 'casing',
+                        msg:
+                            'Parameter "pet_color" has wrong casing. Should be "petColor".',
+                        name: 'parameter-casing',
+                        location: ['components', 'parameters', 'zoo', 'name'],
+                    },
+                ],
+            },
+            {
+                it: 'should not error for all ignored property names',
+                schema: {
+                    components: {
+                        parameters: {
+                            foo: {
+                                name: 'petType',
+                                in: 'query',
+                                schema: {
+                                    type: 'string',
+                                },
+                            },
+                            bar: {
+                                name: 'PET_STORE',
+                                in: 'query',
+                                schema: {
+                                    type: 'string',
+                                },
+                            },
+                            baz: {
+                                name: 'pet-age',
+                                in: 'query',
+                                schema: {
+                                    type: 'string',
+                                },
+                            },
+                            zoo: {
+                                name: 'pet_color',
+                                in: 'query',
+                                schema: {
+                                    type: 'string',
+                                },
                             },
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    msg:
-                        'Parameter "PET_STORE" has wrong casing. Should be "petStore".',
-                    data: {
-                        correctVersion: 'petStore',
-                        name: 'PET_STORE',
+                config: {
+                    rules: {
+                        [rule.name]: [
+                            'camel',
+                            {ignore: ['PET_STORE', 'pet-age']},
+                        ],
                     },
-                    messageId: 'casing',
-                    name: 'parameter-casing',
-                    location: ['components', 'parameters', 'bar', 'name'],
                 },
-                {
-                    msg:
-                        'Parameter "pet-age" has wrong casing. Should be "petAge".',
-                    data: {
-                        correctVersion: 'petAge',
-                        name: 'pet-age',
-                    },
-                    messageId: 'casing',
-                    name: 'parameter-casing',
-                    location: ['components', 'parameters', 'baz', 'name'],
-                },
-                {
-                    data: {
-                        correctVersion: 'petColor',
-                        name: 'pet_color',
-                    },
-                    messageId: 'casing',
-                    msg:
-                        'Parameter "pet_color" has wrong casing. Should be "petColor".',
-                    name: 'parameter-casing',
-                    location: ['components', 'parameters', 'zoo', 'name'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should not error for all ignored property names', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    parameters: {
-                        foo: {
-                            name: 'petType',
-                            in: 'query',
-                            schema: {
-                                type: 'string',
-                            },
-                        },
-                        bar: {
-                            name: 'PET_STORE',
-                            in: 'query',
-                            schema: {
-                                type: 'string',
-                            },
-                        },
-                        baz: {
-                            name: 'pet-age',
-                            in: 'query',
-                            schema: {
-                                type: 'string',
-                            },
-                        },
-                        zoo: {
+                errors: [
+                    {
+                        msg:
+                            'Parameter "pet_color" has wrong casing. Should be "petColor".',
+                        data: {
+                            correctVersion: 'petColor',
                             name: 'pet_color',
-                            in: 'query',
-                            schema: {
-                                type: 'string',
-                            },
                         },
+                        messageId: 'casing',
+                        name: 'parameter-casing',
+                        location: ['components', 'parameters', 'zoo', 'name'],
                     },
-                },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, {
-                rules: {
-                    [rule.name]: ['camel', {ignore: ['PET_STORE', 'pet-age']}],
-                },
-            });
-            const expected = [
-                {
-                    msg:
-                        'Parameter "pet_color" has wrong casing. Should be "petColor".',
-                    data: {
-                        correctVersion: 'petColor',
-                        name: 'pet_color',
-                    },
-                    messageId: 'casing',
-                    name: 'parameter-casing',
-                    location: ['components', 'parameters', 'zoo', 'name'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-
-        it('allows to set different casing for different parameters(in)', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    parameters: {
-                        foo: {
-                            name: 'pet-type',
-                            in: 'path',
-                            required: true,
-                            schema: {
-                                type: 'string',
-                            },
-                        },
-                        bar: {
-                            name: 'petStore',
-                            in: 'cookie',
-                            schema: {
-                                type: 'string',
-                            },
-                        },
-                        baz: {
-                            name: 'pet_color',
-                            in: 'query',
-                            schema: {
-                                type: 'string',
-                            },
-                        },
-                    },
-                },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, {
-                rules: {
-                    [rule.name]: ['camel', {query: 'snake', path: 'kebab'}],
-                },
-            });
-
-            expect(result).toEqual([]);
-        });
-
-        it('allows to ignore parameter names', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    parameters: {
-                        foo: {
-                            name: 'pet-type',
-                            in: 'path',
-                            required: true,
-                            schema: {
-                                type: 'string',
-                            },
-                        },
-                        bar: {
-                            name: 'petStore',
-                            in: 'cookie',
-                            schema: {
-                                type: 'string',
-                            },
-                        },
-                        baz: {
-                            name: 'pet_color',
-                            in: 'query',
-                            schema: {
-                                type: 'string',
-                            },
-                        },
-                    },
-                },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, {
-                rules: {
-                    [rule.name]: ['camel', {ignore: ['pet-type', 'pet_color']}],
-                },
-            });
-
-            expect(result).toEqual([]);
-        });
-    });
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/parameter-casing/spec/index.spec.ts
+++ b/src/rules/parameter-casing/spec/index.spec.ts
@@ -60,18 +60,33 @@ describe(`rule "${rule.name}"`, () => {
             const result = swaggerlint(modConfig, config);
             const expected = [
                 {
+                    data: {
+                        correctVersion: 'petStore',
+                        name: 'PET_STORE',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Parameter "PET_STORE" has wrong casing. Should be "petStore".',
                     name: 'parameter-casing',
                     location: ['paths', '/url', 'parameters', '1', 'name'],
                 },
                 {
+                    data: {
+                        correctVersion: 'petAge',
+                        name: 'pet-age',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Parameter "pet-age" has wrong casing. Should be "petAge".',
                     name: 'parameter-casing',
                     location: ['paths', '/url', 'parameters', '2', 'name'],
                 },
                 {
+                    data: {
+                        correctVersion: 'petColor',
+                        name: 'pet_color',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Parameter "pet_color" has wrong casing. Should be "petColor".',
                     name: 'parameter-casing',
@@ -129,6 +144,11 @@ describe(`rule "${rule.name}"`, () => {
             });
             const expected = [
                 {
+                    data: {
+                        correctVersion: 'petColor',
+                        name: 'pet_color',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Parameter "pet_color" has wrong casing. Should be "petColor".',
                     name: 'parameter-casing',
@@ -281,16 +301,31 @@ describe(`rule "${rule.name}"`, () => {
                 {
                     msg:
                         'Parameter "PET_STORE" has wrong casing. Should be "petStore".',
+                    data: {
+                        correctVersion: 'petStore',
+                        name: 'PET_STORE',
+                    },
+                    messageId: 'casing',
                     name: 'parameter-casing',
                     location: ['components', 'parameters', 'bar', 'name'],
                 },
                 {
                     msg:
                         'Parameter "pet-age" has wrong casing. Should be "petAge".',
+                    data: {
+                        correctVersion: 'petAge',
+                        name: 'pet-age',
+                    },
+                    messageId: 'casing',
                     name: 'parameter-casing',
                     location: ['components', 'parameters', 'baz', 'name'],
                 },
                 {
+                    data: {
+                        correctVersion: 'petColor',
+                        name: 'pet_color',
+                    },
+                    messageId: 'casing',
                     msg:
                         'Parameter "pet_color" has wrong casing. Should be "petColor".',
                     name: 'parameter-casing',
@@ -346,6 +381,11 @@ describe(`rule "${rule.name}"`, () => {
                 {
                     msg:
                         'Parameter "pet_color" has wrong casing. Should be "petColor".',
+                    data: {
+                        correctVersion: 'petColor',
+                        name: 'pet_color',
+                    },
+                    messageId: 'casing',
                     name: 'parameter-casing',
                     location: ['components', 'parameters', 'zoo', 'name'],
                 },

--- a/src/rules/path-param-required-field/index.ts
+++ b/src/rules/path-param-required-field/index.ts
@@ -1,27 +1,39 @@
-import {SwaggerlintRule, Swagger, OpenAPI, Report} from '../../types';
+import {Swagger, OpenAPI, Report} from '../../types';
+import {createRule} from '../../utils';
 
 const name = 'path-param-required-field';
 
 type Param = {
     node: Swagger.ParameterObject | OpenAPI.ParameterObject;
-    report: Report;
+    report: Report<'requiredField'>;
     location: string[];
 };
 
 function ParameterObject({node, report}: Param): void {
     if (!('required' in node)) {
-        report(`Parameter "${node.name}" is missing "required" property`);
+        report({
+            messageId: 'requiredField',
+            data: {
+                name: node.name,
+            },
+        });
     }
 }
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            requiredField:
+                'Parameter "{{name}}" is missing "required" property',
+        },
+    },
     swaggerVisitor: {
         ParameterObject,
     },
     openapiVisitor: {
         ParameterObject,
     },
-};
+});
 
 export default rule;

--- a/src/rules/path-param-required-field/index.ts
+++ b/src/rules/path-param-required-field/index.ts
@@ -2,10 +2,13 @@ import {Swagger, OpenAPI, Report} from '../../types';
 import {createRule} from '../../utils';
 
 const name = 'path-param-required-field';
+const messages = {
+    requiredField: 'Parameter "{{name}}" is missing "required" property',
+};
 
 type Param = {
     node: Swagger.ParameterObject | OpenAPI.ParameterObject;
-    report: Report<'requiredField'>;
+    report: Report<keyof typeof messages>;
     location: string[];
 };
 
@@ -23,10 +26,7 @@ function ParameterObject({node, report}: Param): void {
 const rule = createRule({
     name,
     meta: {
-        messages: {
-            requiredField:
-                'Parameter "{{name}}" is missing "required" property',
-        },
+        messages,
     },
     swaggerVisitor: {
         ParameterObject,

--- a/src/rules/path-param-required-field/spec/index.spec.ts
+++ b/src/rules/path-param-required-field/spec/index.spec.ts
@@ -45,6 +45,10 @@ describe(`rule "${rule.name}"`, () => {
             const result = swaggerlint(modConfig, config);
             const expected = [
                 {
+                    data: {
+                        name: 'sample',
+                    },
+                    messageId: 'requiredField',
                     msg: 'Parameter "sample" is missing "required" property',
                     name: rule.name,
                     location: ['paths', '/url', 'get', 'parameters', '0'],
@@ -80,6 +84,10 @@ describe(`rule "${rule.name}"`, () => {
             const result = swaggerlint(modConfig, config);
             const expected = [
                 {
+                    data: {
+                        name: 'sample',
+                    },
+                    messageId: 'requiredField',
                     msg: 'Parameter "sample" is missing "required" property',
                     name: rule.name,
                     location: ['components', 'parameters', 'sample'],

--- a/src/rules/path-param-required-field/spec/index.spec.ts
+++ b/src/rules/path-param-required-field/spec/index.spec.ts
@@ -1,100 +1,94 @@
 import rule from '../';
 import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
+import {swaggerlint, RuleTester} from '../../../';
 import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
 
-const config: SwaggerlintConfig = {
-    rules: {
-        [rule.name]: true,
-    },
-};
+const ruleTester = new RuleTester(rule);
 
-describe(`rule "${rule.name}"`, () => {
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for parameters missing "required" property', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            parameters: [
-                                {
-                                    in: 'query',
-                                    name: 'sample',
-                                    type: 'string',
-                                },
-                            ],
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        $ref: '#/definitions/lolkekDTO',
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'should not error for an empty schema',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for parameters missing "required" property',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                parameters: [
+                                    {
+                                        in: 'query',
+                                        name: 'sample',
+                                        type: 'string',
+                                    },
+                                ],
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            $ref: '#/definitions/lolkekDTO',
+                                        },
                                     },
                                 },
                             },
                         },
                     },
                 },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    data: {
-                        name: 'sample',
-                    },
-                    messageId: 'requiredField',
-                    msg: 'Parameter "sample" is missing "required" property',
-                    name: rule.name,
-                    location: ['paths', '/url', 'get', 'parameters', '0'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
-
-    describe('openapi', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for parameters missing "required" property', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
-                    parameters: {
-                        sample: {
-                            in: 'query',
+                errors: [
+                    {
+                        data: {
                             name: 'sample',
-                            schema: {
-                                $ref: '',
+                        },
+                        messageId: 'requiredField',
+                        msg:
+                            'Parameter "sample" is missing "required" property',
+                        name: rule.name,
+                        location: ['paths', '/url', 'get', 'parameters', '0'],
+                    },
+                ],
+            },
+        ],
+    },
+    openapi: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for parameters missing "required" property',
+                schema: {
+                    components: {
+                        parameters: {
+                            sample: {
+                                in: 'query',
+                                name: 'sample',
+                                schema: {
+                                    $ref: '',
+                                },
                             },
                         },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    data: {
-                        name: 'sample',
+                errors: [
+                    {
+                        data: {
+                            name: 'sample',
+                        },
+                        messageId: 'requiredField',
+                        msg:
+                            'Parameter "sample" is missing "required" property',
+                        location: ['components', 'parameters', 'sample'],
                     },
-                    messageId: 'requiredField',
-                    msg: 'Parameter "sample" is missing "required" property',
-                    name: rule.name,
-                    location: ['components', 'parameters', 'sample'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/required-operation-tags/index.ts
+++ b/src/rules/required-operation-tags/index.ts
@@ -1,10 +1,11 @@
-import {SwaggerlintRule, Swagger, OpenAPI, Report} from '../../types';
+import {Swagger, OpenAPI, Report} from '../../types';
+import {createRule} from '../../utils';
 
 const name = 'required-operation-tags';
 
 type Param = {
     node: Swagger.OperationObject | OpenAPI.OperationObject;
-    report: Report;
+    report: Report<'missingTags'>;
     location: string[];
 };
 
@@ -12,18 +13,29 @@ function OperationObject({node, report, location}: Param): void {
     if (!Array.isArray(node.tags) || node.tags.length < 1) {
         const method = location[location.length - 1];
         const url = location[location.length - 2];
-        report(`Operation "${method}" in "${url}" is missing tags.`);
+        report({
+            messageId: 'missingTags',
+            data: {
+                method,
+                url,
+            },
+        });
     }
 }
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            missingTags: 'Operation "{{method}}" in "{{url}}" is missing tags.',
+        },
+    },
     swaggerVisitor: {
         OperationObject,
     },
     openapiVisitor: {
         OperationObject,
     },
-};
+});
 
 export default rule;

--- a/src/rules/required-operation-tags/index.ts
+++ b/src/rules/required-operation-tags/index.ts
@@ -2,10 +2,13 @@ import {Swagger, OpenAPI, Report} from '../../types';
 import {createRule} from '../../utils';
 
 const name = 'required-operation-tags';
+const messages = {
+    missingTags: 'Operation "{{method}}" in "{{url}}" is missing tags.',
+};
 
 type Param = {
     node: Swagger.OperationObject | OpenAPI.OperationObject;
-    report: Report<'missingTags'>;
+    report: Report<keyof typeof messages>;
     location: string[];
 };
 
@@ -26,9 +29,7 @@ function OperationObject({node, report, location}: Param): void {
 const rule = createRule({
     name,
     meta: {
-        messages: {
-            missingTags: 'Operation "{{method}}" in "{{url}}" is missing tags.',
-        },
+        messages,
     },
     swaggerVisitor: {
         OperationObject,

--- a/src/rules/required-operation-tags/spec/index.spec.ts
+++ b/src/rules/required-operation-tags/spec/index.spec.ts
@@ -41,7 +41,12 @@ describe(`rule "${rule.name}"`, () => {
                 {
                     msg: 'Operation "get" in "/url" is missing tags.',
                     name: 'required-operation-tags',
+                    data: {
+                        method: 'get',
+                        url: '/url',
+                    },
                     location: ['paths', '/url', 'get'],
+                    messageId: 'missingTags',
                 },
             ];
 
@@ -65,7 +70,12 @@ describe(`rule "${rule.name}"`, () => {
                 {
                     msg: 'Operation "get" in "/url" is missing tags.',
                     name: 'required-operation-tags',
+                    data: {
+                        method: 'get',
+                        url: '/url',
+                    },
                     location: ['paths', '/url', 'get'],
+                    messageId: 'missingTags',
                 },
             ];
 

--- a/src/rules/required-operation-tags/spec/index.spec.ts
+++ b/src/rules/required-operation-tags/spec/index.spec.ts
@@ -1,85 +1,89 @@
 import rule from '../';
-import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../../';
 
-const config: SwaggerlintConfig = {
-    rules: {
-        [rule.name]: true,
-    },
-};
+const ruleTester = new RuleTester(rule);
 
-const mod: Partial<Swagger.SwaggerObject> = {
-    paths: {
-        '/url': {
-            get: {
-                responses: {
-                    default: {
-                        description: 'default response',
-                        schema: {
-                            type: 'string',
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for a tag missing description',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            type: 'string',
+                                        },
+                                    },
+                                },
+                            },
                         },
                     },
                 },
+                errors: [
+                    {
+                        msg: 'Operation "get" in "/url" is missing tags.',
+                        name: 'required-operation-tags',
+                        data: {
+                            method: 'get',
+                            url: '/url',
+                        },
+                        location: ['paths', '/url', 'get'],
+                        messageId: 'missingTags',
+                    },
+                ],
             },
-        },
+        ],
     },
-};
-
-describe(`rule "${rule.name}"`, () => {
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a tag missing description', () => {
-            const schema = getSwaggerObject(mod);
-            const result = swaggerlint(schema, config);
-            const expected = [
-                {
-                    msg: 'Operation "get" in "/url" is missing tags.',
-                    name: 'required-operation-tags',
-                    data: {
-                        method: 'get',
-                        url: '/url',
+    openapi: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for a tag missing description',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            type: 'string',
+                                        },
+                                    },
+                                },
+                            },
+                        },
                     },
-                    location: ['paths', '/url', 'get'],
-                    messageId: 'missingTags',
                 },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
-
-    describe('openapi', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a tag missing description', () => {
-            // @ts-expect-error: not necessary to recreate full object
-            const oMod: Partial<OpenAPI.OpenAPIObject> = {...mod};
-            const schema = getOpenAPIObject(oMod);
-            const result = swaggerlint(schema, config);
-            const expected = [
-                {
-                    msg: 'Operation "get" in "/url" is missing tags.',
-                    name: 'required-operation-tags',
-                    data: {
-                        method: 'get',
-                        url: '/url',
+                errors: [
+                    {
+                        msg: 'Operation "get" in "/url" is missing tags.',
+                        name: 'required-operation-tags',
+                        data: {
+                            method: 'get',
+                            url: '/url',
+                        },
+                        location: ['paths', '/url', 'get'],
+                        messageId: 'missingTags',
                     },
-                    location: ['paths', '/url', 'get'],
-                    messageId: 'missingTags',
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/required-parameter-description/index.ts
+++ b/src/rules/required-parameter-description/index.ts
@@ -2,10 +2,13 @@ import {Swagger, OpenAPI, Report} from '../../types';
 import {createRule} from '../../utils';
 
 const name = 'required-parameter-description';
+const messages = {
+    missingDesc: '"{{name}}" parameter is missing description.',
+};
 
 type Param = {
     node: Swagger.ParameterObject | OpenAPI.ParameterObject;
-    report: Report<'missingDesc'>;
+    report: Report<keyof typeof messages>;
     location: string[];
 };
 
@@ -31,9 +34,7 @@ function ParameterObject({node, report, location}: Param): void {
 const rule = createRule({
     name,
     meta: {
-        messages: {
-            missingDesc: '"{{name}}" parameter is missing description.',
-        },
+        messages,
     },
     swaggerVisitor: {
         ParameterObject,

--- a/src/rules/required-parameter-description/index.ts
+++ b/src/rules/required-parameter-description/index.ts
@@ -1,32 +1,46 @@
-import {SwaggerlintRule, Swagger, OpenAPI, Report} from '../../types';
+import {Swagger, OpenAPI, Report} from '../../types';
+import {createRule} from '../../utils';
 
 const name = 'required-parameter-description';
 
 type Param = {
     node: Swagger.ParameterObject | OpenAPI.ParameterObject;
-    report: Report;
+    report: Report<'missingDesc'>;
     location: string[];
 };
 
 function ParameterObject({node, report, location}: Param): void {
     if (!('description' in node)) {
-        report(`"${node.name}" parameter is missing description.`);
+        report({
+            messageId: 'missingDesc',
+            data: {
+                name: node.name,
+            },
+        });
     } else if (typeof node.description === 'string' && !node.description) {
-        report(`"${node.name}" parameter is missing description.`, [
-            ...location,
-            'description',
-        ]);
+        report({
+            messageId: 'missingDesc',
+            data: {
+                name: node.name,
+            },
+            location: [...location, 'description'],
+        });
     }
 }
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            missingDesc: '"{{name}}" parameter is missing description.',
+        },
+    },
     swaggerVisitor: {
         ParameterObject,
     },
     openapiVisitor: {
         ParameterObject,
     },
-};
+});
 
 export default rule;

--- a/src/rules/required-parameter-description/spec/index.spec.ts
+++ b/src/rules/required-parameter-description/spec/index.spec.ts
@@ -80,21 +80,37 @@ describe(`rule "${rule.name}"`, () => {
             const expected = [
                 {
                     msg: '"petId" parameter is missing description.',
+                    messageId: 'missingDesc',
+                    data: {
+                        name: 'petId',
+                    },
                     name: 'required-parameter-description',
                     location: ['paths', '/url', 'get', 'parameters', '0'],
                 },
                 {
                     msg: '"petName" parameter is missing description.',
+                    messageId: 'missingDesc',
+                    data: {
+                        name: 'petName',
+                    },
                     name: 'required-parameter-description',
                     location: ['paths', '/url', 'parameters', '0'],
                 },
                 {
                     msg: '"petAge" parameter is missing description.',
+                    messageId: 'missingDesc',
+                    data: {
+                        name: 'petAge',
+                    },
                     name: 'required-parameter-description',
                     location: ['parameters', 'petAge'],
                 },
                 {
                     msg: '"emptyDesc" parameter is missing description.',
+                    messageId: 'missingDesc',
+                    data: {
+                        name: 'emptyDesc',
+                    },
                     name: 'required-parameter-description',
                     location: ['parameters', 'emptyDesc', 'description'],
                 },
@@ -131,6 +147,10 @@ describe(`rule "${rule.name}"`, () => {
             const expected = [
                 {
                     msg: '"petId" parameter is missing description.',
+                    messageId: 'missingDesc',
+                    data: {
+                        name: 'petId',
+                    },
                     name: rule.name,
                     location: ['components', 'parameters', 'petId'],
                 },

--- a/src/rules/required-parameter-description/spec/index.spec.ts
+++ b/src/rules/required-parameter-description/spec/index.spec.ts
@@ -1,162 +1,153 @@
 import rule from '../';
-import {Swagger, SwaggerlintConfig, OpenAPI} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../../';
 
-const config: SwaggerlintConfig = {
-    rules: {
-        [rule.name]: true,
-    },
-};
+const ruleTester = new RuleTester(rule);
 
-describe(`rule "${rule.name}"`, () => {
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a url ending with a slash', () => {
-            const mod: Partial<Swagger.SwaggerObject> = {
-                paths: {
-                    '/url': {
-                        get: {
-                            responses: {
-                                default: {
-                                    description: 'default response',
-                                    schema: {
-                                        type: 'string',
+ruleTester.run({
+    swagger: {
+        valid: [
+            {
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for parameters with no description',
+                schema: {
+                    paths: {
+                        '/url': {
+                            get: {
+                                responses: {
+                                    default: {
+                                        description: 'default response',
+                                        schema: {
+                                            type: 'string',
+                                        },
                                     },
                                 },
+                                parameters: [
+                                    {
+                                        name: 'petId',
+                                        in: 'path',
+                                        required: true,
+                                        type: 'string',
+                                    },
+                                ],
                             },
                             parameters: [
                                 {
-                                    name: 'petId',
-                                    in: 'path',
+                                    name: 'petName',
+                                    in: 'query',
                                     required: true,
                                     type: 'string',
                                 },
                             ],
                         },
-                        parameters: [
-                            {
-                                name: 'petName',
-                                in: 'query',
-                                required: true,
-                                type: 'string',
-                            },
-                        ],
                     },
-                },
-                parameters: {
-                    petAge: {
-                        name: 'petAge',
-                        in: 'body',
-                        required: true,
-                        schema: {
-                            type: 'string',
-                        },
-                    },
-                    petColor: {
-                        name: 'petColor',
-                        in: 'body',
-                        description: 'color of required pet',
-                        required: true,
-                        schema: {
-                            type: 'string',
-                        },
-                    },
-                    emptyDesc: {
-                        name: 'emptyDesc',
-                        in: 'query',
-                        description: '',
-                        type: 'string',
-                    },
-                },
-            };
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    msg: '"petId" parameter is missing description.',
-                    messageId: 'missingDesc',
-                    data: {
-                        name: 'petId',
-                    },
-                    name: 'required-parameter-description',
-                    location: ['paths', '/url', 'get', 'parameters', '0'],
-                },
-                {
-                    msg: '"petName" parameter is missing description.',
-                    messageId: 'missingDesc',
-                    data: {
-                        name: 'petName',
-                    },
-                    name: 'required-parameter-description',
-                    location: ['paths', '/url', 'parameters', '0'],
-                },
-                {
-                    msg: '"petAge" parameter is missing description.',
-                    messageId: 'missingDesc',
-                    data: {
-                        name: 'petAge',
-                    },
-                    name: 'required-parameter-description',
-                    location: ['parameters', 'petAge'],
-                },
-                {
-                    msg: '"emptyDesc" parameter is missing description.',
-                    messageId: 'missingDesc',
-                    data: {
-                        name: 'emptyDesc',
-                    },
-                    name: 'required-parameter-description',
-                    location: ['parameters', 'emptyDesc', 'description'],
-                },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
-
-    describe('openapi', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a url ending with a slash', () => {
-            const mod: Partial<OpenAPI.OpenAPIObject> = {
-                components: {
                     parameters: {
-                        petId: {
-                            name: 'petId',
-                            in: 'path',
+                        petAge: {
+                            name: 'petAge',
+                            in: 'body',
                             required: true,
                             schema: {
                                 type: 'string',
                             },
                         },
+                        petColor: {
+                            name: 'petColor',
+                            in: 'body',
+                            description: 'color of required pet',
+                            required: true,
+                            schema: {
+                                type: 'string',
+                            },
+                        },
+                        emptyDesc: {
+                            name: 'emptyDesc',
+                            in: 'query',
+                            description: '',
+                            type: 'string',
+                        },
                     },
                 },
-            };
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    msg: '"petId" parameter is missing description.',
-                    messageId: 'missingDesc',
-                    data: {
-                        name: 'petId',
+                errors: [
+                    {
+                        msg: '"petId" parameter is missing description.',
+                        messageId: 'missingDesc',
+                        data: {
+                            name: 'petId',
+                        },
+                        name: 'required-parameter-description',
+                        location: ['paths', '/url', 'get', 'parameters', '0'],
                     },
-                    name: rule.name,
-                    location: ['components', 'parameters', 'petId'],
+                    {
+                        msg: '"petName" parameter is missing description.',
+                        messageId: 'missingDesc',
+                        data: {
+                            name: 'petName',
+                        },
+                        name: 'required-parameter-description',
+                        location: ['paths', '/url', 'parameters', '0'],
+                    },
+                    {
+                        msg: '"petAge" parameter is missing description.',
+                        messageId: 'missingDesc',
+                        data: {
+                            name: 'petAge',
+                        },
+                        name: 'required-parameter-description',
+                        location: ['parameters', 'petAge'],
+                    },
+                    {
+                        msg: '"emptyDesc" parameter is missing description.',
+                        messageId: 'missingDesc',
+                        data: {
+                            name: 'emptyDesc',
+                        },
+                        name: 'required-parameter-description',
+                        location: ['parameters', 'emptyDesc', 'description'],
+                    },
+                ],
+            },
+        ],
+    },
+    openapi: {
+        valid: [
+            {
+                it: 'should NOT error for an empty schema',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for a parameters with no description',
+                schema: {
+                    components: {
+                        parameters: {
+                            petId: {
+                                name: 'petId',
+                                in: 'path',
+                                required: true,
+                                schema: {
+                                    type: 'string',
+                                },
+                            },
+                        },
+                    },
                 },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
+                errors: [
+                    {
+                        msg: '"petId" parameter is missing description.',
+                        messageId: 'missingDesc',
+                        data: {
+                            name: 'petId',
+                        },
+                        name: rule.name,
+                        location: ['components', 'parameters', 'petId'],
+                    },
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/required-tag-description/index.ts
+++ b/src/rules/required-tag-description/index.ts
@@ -2,10 +2,13 @@ import {Swagger, OpenAPI, Report} from '../../types';
 import {createRule} from '../../utils';
 
 const name = 'required-tag-description';
+const messages = {
+    missingDesc: 'Tag "{{name}}" is missing description.',
+};
 
 type Param = {
     node: Swagger.TagObject | OpenAPI.TagObject;
-    report: Report<'missingDesc'>;
+    report: Report<keyof typeof messages>;
     location: string[];
 };
 
@@ -33,9 +36,7 @@ function TagObject({node, report, location}: Param): void {
 const rule = createRule({
     name,
     meta: {
-        messages: {
-            missingDesc: 'Tag "{{name}}" is missing description.',
-        },
+        messages,
     },
     swaggerVisitor: {
         TagObject,

--- a/src/rules/required-tag-description/index.ts
+++ b/src/rules/required-tag-description/index.ts
@@ -1,34 +1,48 @@
-import {SwaggerlintRule, Swagger, OpenAPI, Report} from '../../types';
+import {Swagger, OpenAPI, Report} from '../../types';
+import {createRule} from '../../utils';
 
 const name = 'required-tag-description';
 
 type Param = {
     node: Swagger.TagObject | OpenAPI.TagObject;
-    report: Report;
+    report: Report<'missingDesc'>;
     location: string[];
 };
 
 function TagObject({node, report, location}: Param): void {
     if (!('description' in node)) {
-        report(`Tag "${node.name}" is missing description.`);
+        report({
+            messageId: 'missingDesc',
+            data: {
+                name: node.name,
+            },
+        });
         return;
     }
     if (!node.description) {
-        report(`Tag "${node.name}" is missing description.`, [
-            ...location,
-            'description',
-        ]);
+        report({
+            messageId: 'missingDesc',
+            data: {
+                name: node.name,
+            },
+            location: [...location, 'description'],
+        });
     }
 }
 
-const rule: SwaggerlintRule = {
+const rule = createRule({
     name,
+    meta: {
+        messages: {
+            missingDesc: 'Tag "{{name}}" is missing description.',
+        },
+    },
     swaggerVisitor: {
         TagObject,
     },
     openapiVisitor: {
         TagObject,
     },
-};
+});
 
 export default rule;

--- a/src/rules/required-tag-description/spec/index.spec.ts
+++ b/src/rules/required-tag-description/spec/index.spec.ts
@@ -1,76 +1,76 @@
 import rule from '../';
-import {SwaggerlintConfig} from '../../../types';
-import {swaggerlint} from '../../../';
-import {getSwaggerObject, getOpenAPIObject} from '../../../utils/tests';
+import {RuleTester} from '../../../';
 
-describe(`rule "${rule.name}"`, () => {
-    const config: SwaggerlintConfig = {
-        rules: {
-            [rule.name]: true,
-        },
-    };
+const ruleTester = new RuleTester(rule);
 
-    const mod = {
-        tags: [
+ruleTester.run({
+    swagger: {
+        valid: [
             {
-                name: 'no-description',
-            },
-            {
-                name: 'with-description',
-                description: 'some description about the tag',
+                it: 'should NOT error for an empty swagger sample',
+                schema: {},
             },
         ],
-    };
-
-    describe('swagger', () => {
-        it('should NOT error for an empty swagger sample', () => {
-            const result = swaggerlint(getSwaggerObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a tag missing description', () => {
-            const modConfig = getSwaggerObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    msg: 'Tag "no-description" is missing description.',
-                    name: 'required-tag-description',
-                    location: ['tags', '0'],
-                    messageId: 'missingDesc',
-                    data: {
-                        name: 'no-description',
-                    },
+        invalid: [
+            {
+                it: 'should error for a tag missing description',
+                schema: {
+                    tags: [
+                        {
+                            name: 'no-description',
+                        },
+                        {
+                            name: 'with-description',
+                            description: 'some description about the tag',
+                        },
+                    ],
                 },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
-
-    describe('openapi', () => {
-        it('should NOT error for an empty openapi sample', () => {
-            const result = swaggerlint(getOpenAPIObject({}), config);
-
-            expect(result).toEqual([]);
-        });
-
-        it('should error for a tag missing description', () => {
-            const modConfig = getOpenAPIObject(mod);
-            const result = swaggerlint(modConfig, config);
-            const expected = [
-                {
-                    msg: 'Tag "no-description" is missing description.',
-                    name: 'required-tag-description',
-                    messageId: 'missingDesc',
-                    data: {
-                        name: 'no-description',
+                errors: [
+                    {
+                        msg: 'Tag "no-description" is missing description.',
+                        location: ['tags', '0'],
+                        messageId: 'missingDesc',
+                        data: {
+                            name: 'no-description',
+                        },
                     },
-                    location: ['tags', '0'],
+                ],
+            },
+        ],
+    },
+    openapi: {
+        valid: [
+            {
+                it: 'should NOT error for an empty openapi sample',
+                schema: {},
+            },
+        ],
+        invalid: [
+            {
+                it: 'should error for a tag missing description',
+                schema: {
+                    tags: [
+                        {
+                            name: 'no-description',
+                        },
+                        {
+                            name: 'with-description',
+                            description: 'some description about the tag',
+                        },
+                    ],
                 },
-            ];
-
-            expect(result).toEqual(expected);
-        });
-    });
+                errors: [
+                    {
+                        msg: 'Tag "no-description" is missing description.',
+                        name: 'required-tag-description',
+                        messageId: 'missingDesc',
+                        data: {
+                            name: 'no-description',
+                        },
+                        location: ['tags', '0'],
+                    },
+                ],
+            },
+        ],
+    },
 });

--- a/src/rules/required-tag-description/spec/index.spec.ts
+++ b/src/rules/required-tag-description/spec/index.spec.ts
@@ -37,6 +37,10 @@ describe(`rule "${rule.name}"`, () => {
                     msg: 'Tag "no-description" is missing description.',
                     name: 'required-tag-description',
                     location: ['tags', '0'],
+                    messageId: 'missingDesc',
+                    data: {
+                        name: 'no-description',
+                    },
                 },
             ];
 
@@ -45,7 +49,7 @@ describe(`rule "${rule.name}"`, () => {
     });
 
     describe('openapi', () => {
-        it('should NOT error for an empty swagger sample', () => {
+        it('should NOT error for an empty openapi sample', () => {
             const result = swaggerlint(getOpenAPIObject({}), config);
 
             expect(result).toEqual([]);
@@ -58,6 +62,10 @@ describe(`rule "${rule.name}"`, () => {
                 {
                     msg: 'Tag "no-description" is missing description.',
                     name: 'required-tag-description',
+                    messageId: 'missingDesc',
+                    data: {
+                        name: 'no-description',
+                    },
                     location: ['tags', '0'],
                 },
             ];

--- a/src/swaggerlint.ts
+++ b/src/swaggerlint.ts
@@ -179,15 +179,6 @@ export function swaggerlint(
                      */
                     ({node, location}) => {
                         const report = makeReportFunc(errors, rule, location);
-                        // const report = (
-                        //     msg: string,
-                        //     rLocation?: string[],
-                        // ): void =>
-                        //     void errors.push({
-                        //         msg,
-                        //         name: rule.name,
-                        //         location: rLocation ?? location,
-                        //     });
                         if (typeof check === 'function') {
                             /**
                              * ts manages to only infer example object here,
@@ -219,15 +210,6 @@ export function swaggerlint(
                 specificVisitor.forEach(
                     ({node, location}: NodeWithLocation<CurrentObject>) => {
                         const report = makeReportFunc(errors, rule, location);
-                        // const report = (
-                        //     msg: string,
-                        //     rLocation?: string[],
-                        // ): void =>
-                        //     void errors.push({
-                        //         msg,
-                        //         name: rule.name,
-                        //         location: rLocation ?? location,
-                        //     });
 
                         check({node, location, setting, report, config});
                     },

--- a/src/swaggerlint.ts
+++ b/src/swaggerlint.ts
@@ -229,6 +229,7 @@ function makeReportFunc<MessageIds extends string>(
     return function (arg): void {
         if (hasKey('messageId', arg) && arg.messageId) {
             const msgTemplate = rule.meta?.messages?.[arg.messageId] || '';
+            // TODO: return an error for the rule if `messageId` is unknown
             /* eslint-disable indent */
             const message: string = arg.data
                 ? Object.keys(arg.data).reduce((acc, key) => {

--- a/src/types/swaggerlint.ts
+++ b/src/types/swaggerlint.ts
@@ -58,60 +58,87 @@ export type SwaggerlintConfig = {
     ignore?: ConfigIgnore;
 };
 
-export type LintError = {
+type LintErrorPlain = {
     name: string;
     msg: string;
     location: string[];
 };
+type LintErrorWithMsgId = {
+    name: string;
+    msg: string;
+    location: string[];
+    messageId: string;
+    data?: Record<string, unknown>;
+};
+export type LintError = LintErrorPlain | LintErrorWithMsgId;
 
-export type Report = (msg: string, location?: string[]) => void;
-export type RuleVisitorFunction<T> = (a: {
+type ReportArgSimple = {
+    message: string;
+    location?: string[];
+};
+type ReportArgComplex<M extends string> = {
+    messageId: M;
+    /**
+     * Object with data to populate the message template.
+     */
+    data?: Record<string, unknown>;
+    location?: string[];
+};
+export type Report<M extends string> = (
+    arg: ReportArgSimple | ReportArgComplex<M>,
+) => void;
+export type RuleVisitorFunction<T, MessageIds extends string> = (a: {
     node: T;
     location: string[];
-    report: Report;
+    report: Report<MessageIds>;
     setting: SwaggerlintRuleSetting; // TODO
     config: SwaggerlintConfig; // TODO move this and above into rule arg
 }) => void;
 
-export type SwaggerVisitorName = keyof SwaggerRuleVisitor;
+export type SwaggerVisitorName = keyof SwaggerRuleVisitor<''>;
 
-export type SwaggerRuleVisitor = Partial<{
-    SwaggerObject: RuleVisitorFunction<Swagger.SwaggerObject>;
-    InfoObject: RuleVisitorFunction<Swagger.InfoObject>;
-    PathsObject: RuleVisitorFunction<Swagger.PathsObject>;
+export type SwaggerRuleVisitor<M extends string> = Partial<{
+    SwaggerObject: RuleVisitorFunction<Swagger.SwaggerObject, M>;
+    InfoObject: RuleVisitorFunction<Swagger.InfoObject, M>;
+    PathsObject: RuleVisitorFunction<Swagger.PathsObject, M>;
 
-    DefinitionsObject: RuleVisitorFunction<Swagger.DefinitionsObject>;
+    DefinitionsObject: RuleVisitorFunction<Swagger.DefinitionsObject, M>;
     ParametersDefinitionsObject: RuleVisitorFunction<
-        Swagger.ParametersDefinitionsObject
+        Swagger.ParametersDefinitionsObject,
+        M
     >;
     ResponsesDefinitionsObject: RuleVisitorFunction<
-        Swagger.ResponsesDefinitionsObject
+        Swagger.ResponsesDefinitionsObject,
+        M
     >;
     SecurityDefinitionsObject: RuleVisitorFunction<
-        Swagger.SecurityDefinitionsObject
+        Swagger.SecurityDefinitionsObject,
+        M
     >;
-    SecuritySchemeObject: RuleVisitorFunction<Swagger.SecuritySchemeObject>;
-    ScopesObject: RuleVisitorFunction<Swagger.ScopesObject>;
+    SecuritySchemeObject: RuleVisitorFunction<Swagger.SecuritySchemeObject, M>;
+    ScopesObject: RuleVisitorFunction<Swagger.ScopesObject, M>;
     SecurityRequirementObject: RuleVisitorFunction<
-        Swagger.SecurityRequirementObject
+        Swagger.SecurityRequirementObject,
+        M
     >;
-    TagObject: RuleVisitorFunction<Swagger.TagObject>;
+    TagObject: RuleVisitorFunction<Swagger.TagObject, M>;
     ExternalDocumentationObject: RuleVisitorFunction<
-        Swagger.ExternalDocumentationObject
+        Swagger.ExternalDocumentationObject,
+        M
     >;
-    ContactObject: RuleVisitorFunction<Swagger.ContactObject>;
-    LicenseObject: RuleVisitorFunction<Swagger.LicenseObject>;
-    PathItemObject: RuleVisitorFunction<Swagger.PathItemObject>;
-    OperationObject: RuleVisitorFunction<Swagger.OperationObject>;
-    ParameterObject: RuleVisitorFunction<Swagger.ParameterObject>;
-    ResponsesObject: RuleVisitorFunction<Swagger.ResponsesObject>;
-    ResponseObject: RuleVisitorFunction<Swagger.ResponseObject>;
-    SchemaObject: RuleVisitorFunction<Swagger.SchemaObject>;
-    XMLObject: RuleVisitorFunction<Swagger.XMLObject>;
-    HeadersObject: RuleVisitorFunction<Swagger.HeadersObject>;
-    HeaderObject: RuleVisitorFunction<Swagger.HeaderObject>;
-    ItemsObject: RuleVisitorFunction<Swagger.ItemsObject>;
-    ExampleObject: RuleVisitorFunction<Swagger.ExampleObject>;
+    ContactObject: RuleVisitorFunction<Swagger.ContactObject, M>;
+    LicenseObject: RuleVisitorFunction<Swagger.LicenseObject, M>;
+    PathItemObject: RuleVisitorFunction<Swagger.PathItemObject, M>;
+    OperationObject: RuleVisitorFunction<Swagger.OperationObject, M>;
+    ParameterObject: RuleVisitorFunction<Swagger.ParameterObject, M>;
+    ResponsesObject: RuleVisitorFunction<Swagger.ResponsesObject, M>;
+    ResponseObject: RuleVisitorFunction<Swagger.ResponseObject, M>;
+    SchemaObject: RuleVisitorFunction<Swagger.SchemaObject, M>;
+    XMLObject: RuleVisitorFunction<Swagger.XMLObject, M>;
+    HeadersObject: RuleVisitorFunction<Swagger.HeadersObject, M>;
+    HeaderObject: RuleVisitorFunction<Swagger.HeaderObject, M>;
+    ItemsObject: RuleVisitorFunction<Swagger.ItemsObject, M>;
+    ExampleObject: RuleVisitorFunction<Swagger.ExampleObject, M>;
 }>;
 
 type OneOrNone<T> = [T] | [];
@@ -226,52 +253,59 @@ export type OpenAPITypes = {
     XMLObject: OpenAPI.XMLObject;
 };
 
-export type OpenAPIVisitorName = keyof OpenAPIRuleVisitor;
+export type OpenAPIVisitorName = keyof OpenAPIRuleVisitor<''>;
 
-type OpenAPIRuleVisitor = Partial<{
-    CallbackObject: RuleVisitorFunction<OpenAPI.CallbackObject>;
-    ComponentsObject: RuleVisitorFunction<OpenAPI.ComponentsObject>;
-    ContactObject: RuleVisitorFunction<OpenAPI.ContactObject>;
-    DiscriminatorObject: RuleVisitorFunction<OpenAPI.DiscriminatorObject>;
-    EncodingObject: RuleVisitorFunction<OpenAPI.EncodingObject>;
-    ExampleObject: RuleVisitorFunction<OpenAPI.ExampleObject>;
+type OpenAPIRuleVisitor<M extends string> = Partial<{
+    CallbackObject: RuleVisitorFunction<OpenAPI.CallbackObject, M>;
+    ComponentsObject: RuleVisitorFunction<OpenAPI.ComponentsObject, M>;
+    ContactObject: RuleVisitorFunction<OpenAPI.ContactObject, M>;
+    DiscriminatorObject: RuleVisitorFunction<OpenAPI.DiscriminatorObject, M>;
+    EncodingObject: RuleVisitorFunction<OpenAPI.EncodingObject, M>;
+    ExampleObject: RuleVisitorFunction<OpenAPI.ExampleObject, M>;
     ExternalDocumentationObject: RuleVisitorFunction<
-        OpenAPI.ExternalDocumentationObject
+        OpenAPI.ExternalDocumentationObject,
+        M
     >;
-    HeaderObject: RuleVisitorFunction<OpenAPI.HeaderObject>;
-    InfoObject: RuleVisitorFunction<OpenAPI.InfoObject>;
-    LicenseObject: RuleVisitorFunction<OpenAPI.LicenseObject>;
-    LinkObject: RuleVisitorFunction<OpenAPI.LinkObject>;
-    MediaTypeObject: RuleVisitorFunction<OpenAPI.MediaTypeObject>;
-    OAuthFlowObject: RuleVisitorFunction<OpenAPI.OAuthFlowObject>;
-    OAuthFlowsObject: RuleVisitorFunction<OpenAPI.OAuthFlowsObject>;
-    OpenAPIObject: RuleVisitorFunction<OpenAPI.OpenAPIObject>;
-    OperationObject: RuleVisitorFunction<OpenAPI.OperationObject>;
-    ParameterObject: RuleVisitorFunction<OpenAPI.ParameterObject>;
-    PathItemObject: RuleVisitorFunction<OpenAPI.PathItemObject>;
-    PathsObject: RuleVisitorFunction<OpenAPI.PathsObject>;
-    ReferenceObject: RuleVisitorFunction<OpenAPI.ReferenceObject>;
-    RequestBodyObject: RuleVisitorFunction<OpenAPI.RequestBodyObject>;
-    ResponseObject: RuleVisitorFunction<OpenAPI.ResponseObject>;
-    ResponsesObject: RuleVisitorFunction<OpenAPI.ResponsesObject>;
-    SchemaObject: RuleVisitorFunction<OpenAPI.SchemaObject>;
+    HeaderObject: RuleVisitorFunction<OpenAPI.HeaderObject, M>;
+    InfoObject: RuleVisitorFunction<OpenAPI.InfoObject, M>;
+    LicenseObject: RuleVisitorFunction<OpenAPI.LicenseObject, M>;
+    LinkObject: RuleVisitorFunction<OpenAPI.LinkObject, M>;
+    MediaTypeObject: RuleVisitorFunction<OpenAPI.MediaTypeObject, M>;
+    OAuthFlowObject: RuleVisitorFunction<OpenAPI.OAuthFlowObject, M>;
+    OAuthFlowsObject: RuleVisitorFunction<OpenAPI.OAuthFlowsObject, M>;
+    OpenAPIObject: RuleVisitorFunction<OpenAPI.OpenAPIObject, M>;
+    OperationObject: RuleVisitorFunction<OpenAPI.OperationObject, M>;
+    ParameterObject: RuleVisitorFunction<OpenAPI.ParameterObject, M>;
+    PathItemObject: RuleVisitorFunction<OpenAPI.PathItemObject, M>;
+    PathsObject: RuleVisitorFunction<OpenAPI.PathsObject, M>;
+    ReferenceObject: RuleVisitorFunction<OpenAPI.ReferenceObject, M>;
+    RequestBodyObject: RuleVisitorFunction<OpenAPI.RequestBodyObject, M>;
+    ResponseObject: RuleVisitorFunction<OpenAPI.ResponseObject, M>;
+    ResponsesObject: RuleVisitorFunction<OpenAPI.ResponsesObject, M>;
+    SchemaObject: RuleVisitorFunction<OpenAPI.SchemaObject, M>;
     SecurityRequirementObject: RuleVisitorFunction<
-        OpenAPI.SecurityRequirementObject
+        OpenAPI.SecurityRequirementObject,
+        M
     >;
-    SecuritySchemeObject: RuleVisitorFunction<OpenAPI.SecuritySchemeObject>;
-    ServerObject: RuleVisitorFunction<OpenAPI.ServerObject>;
-    ServerVariableObject: RuleVisitorFunction<OpenAPI.ServerVariableObject>;
-    TagObject: RuleVisitorFunction<OpenAPI.TagObject>;
-    XMLObject: RuleVisitorFunction<OpenAPI.XMLObject>;
+    SecuritySchemeObject: RuleVisitorFunction<OpenAPI.SecuritySchemeObject, M>;
+    ServerObject: RuleVisitorFunction<OpenAPI.ServerObject, M>;
+    ServerVariableObject: RuleVisitorFunction<OpenAPI.ServerVariableObject, M>;
+    TagObject: RuleVisitorFunction<OpenAPI.TagObject, M>;
+    XMLObject: RuleVisitorFunction<OpenAPI.XMLObject, M>;
 }>;
 
-type SwaggerlintRulePrimitive = {
+type SwaggerlintRulePrimitive<T extends string> = {
     name: string;
-    openapiVisitor?: OpenAPIRuleVisitor;
-    swaggerVisitor?: SwaggerRuleVisitor;
+    meta?: {
+        messages: Record<T, string>;
+    };
+    openapiVisitor?: OpenAPIRuleVisitor<T>;
+    swaggerVisitor?: SwaggerRuleVisitor<T>;
 };
 
-type SwaggerlintRuleWithSetting = SwaggerlintRulePrimitive & {
+type SwaggerlintRuleWithSetting<T extends string> = SwaggerlintRulePrimitive<
+    T
+> & {
     /**
      * Verification of valid setting for the rule,
      * no need to verify boolean settings.
@@ -282,6 +316,6 @@ type SwaggerlintRuleWithSetting = SwaggerlintRulePrimitive & {
     defaultSetting: SwaggerlintRuleSetting;
 };
 
-export type SwaggerlintRule =
-    | SwaggerlintRulePrimitive
-    | SwaggerlintRuleWithSetting;
+export type SwaggerlintRule<T extends string | never> =
+    | SwaggerlintRulePrimitive<T>
+    | SwaggerlintRuleWithSetting<T>;

--- a/src/types/swaggerlint.ts
+++ b/src/types/swaggerlint.ts
@@ -81,7 +81,7 @@ type ReportArgComplex<M extends string> = {
     /**
      * Object with data to populate the message template.
      */
-    data?: Record<string, unknown>;
+    data?: Record<string, string | number>;
     location?: string[];
 };
 export type Report<M extends string> = (
@@ -316,6 +316,6 @@ type SwaggerlintRuleWithSetting<T extends string> = SwaggerlintRulePrimitive<
     defaultSetting: SwaggerlintRuleSetting;
 };
 
-export type SwaggerlintRule<T extends string | never> =
+export type SwaggerlintRule<T extends string> =
     | SwaggerlintRulePrimitive<T>
     | SwaggerlintRuleWithSetting<T>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import {SwaggerVisitorName, Swagger} from '../types';
+import {SwaggerVisitorName, Swagger, SwaggerlintRule} from '../types';
 export * from './common';
 
 const isDev = process.env.NODE_ENV === 'development';
@@ -69,4 +69,10 @@ export function isValidCaseName(
     name: string | void,
 ): name is keyof typeof validCases {
     return name in validCases;
+}
+
+export function createRule<T extends string>(
+    rule: SwaggerlintRule<T>,
+): typeof rule {
+    return rule;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -74,5 +74,6 @@ export function isValidCaseName(
 export function createRule<T extends string>(
     rule: SwaggerlintRule<T>,
 ): typeof rule {
+    // TODO: add rule validations
     return rule;
 }


### PR DESCRIPTION
This PR introduces:
- a new field in rules called `meta`. There messages can be stored to reuse them inside visitors. No need to inline and copy paste message strings from visitor to visitor. Fixes #39 
- RuleTester. A utility that should help to test rules decoratively and lower the learning curve.