### PR TITLE
add ignore characters options for latin-definions-only rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,25 +83,25 @@ module.exports = {
 
 You can set any rule value to `false` to disable it or to `true` to enable and set its setting to default value.
 
-<!-- GENERATED_START(id:rulestable;hash:fabc22cf76c6c24537384901aef3da52) This is generated content, do not modify by hand, to regenerate run "npm run updateDocs" -->
+<!-- GENERATED_START(id:rulestable;hash:78f3b724d8ef667a4bcef20d6c92d22e) This is generated content, do not modify by hand, to regenerate run "npm run updateDocs" -->
 
-| rule name                                                                                | description                                                                    | default                      |
-| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ---------------------------- |
-| [`expressive-path-summary`](./src/rules/expressive-path-summary/readme.md)               | Enforces an intentional path summary                                           |                              |
-| [`latin-definitions-only`](./src/rules/latin-definitions-only/readme.md)                 | Bans non Latin characters usage in definition names                            |                              |
-| [`no-empty-object-type`](./src/rules/no-empty-object-type/readme.md)                     | Object types have to have their properties specified explicitly                |                              |
-| [`no-external-refs`](./src/rules/no-external-refs/readme.md)                             | Forbids the usage of external ReferenceObjects                                 |                              |
-| [`no-inline-enums`](./src/rules/no-inline-enums/readme.md)                               | Enums must be in `DefinitionsObject` or `ComponentsObject`                     |                              |
-| [`no-ref-properties`](./src/rules/no-ref-properties/readme.md)                           | Disallows to have additional properties in Reference objects                   |                              |
-| [`no-single-allof`](./src/rules/no-single-allof/readme.md)                               | Object types should not have a redundant single `allOf` property               |                              |
-| [`no-trailing-slash`](./src/rules/no-trailing-slash/readme.md)                           | URLs must NOT end with a slash                                                 |                              |
-| [`object-prop-casing`](./src/rules/object-prop-casing/readme.md)                         | Casing for your object property names                                          | ["camel"]                    |
-| [`only-valid-mime-types`](./src/rules/only-valid-mime-types/readme.md)                   | Checks mime types against known from [`mime-db`](https://npm.im/mime-db)       |                              |
-| [`parameter-casing`](./src/rules/parameter-casing/readme.md)                             | Casing for your parameters                                                     | ["camel",{"header":"kebab"}] |
-| [`path-param-required-field`](./src/rules/path-param-required-field/readme.md)           | Helps to keep consistently set optional `required` property in path parameters |                              |
-| [`required-operation-tags`](./src/rules/required-operation-tags/readme.md)               | All operations must have tags                                                  |                              |
-| [`required-parameter-description`](./src/rules/required-parameter-description/readme.md) | All parameters must have description                                           |                              |
-| [`required-tag-description`](./src/rules/required-tag-description/readme.md)             | All tags must have description                                                 |                              |
+| rule name                                                                                | description                                                                    | default                                     |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------- |
+| [`expressive-path-summary`](./src/rules/expressive-path-summary/readme.md)               | Enforces an intentional path summary                                           |                                             |
+| [`latin-definitions-only`](./src/rules/latin-definitions-only/readme.md)                 | Bans non Latin characters usage in definition names                            | ["placeholder_to_be_removed",{"ignore":[]}] |
+| [`no-empty-object-type`](./src/rules/no-empty-object-type/readme.md)                     | Object types have to have their properties specified explicitly                |                                             |
+| [`no-external-refs`](./src/rules/no-external-refs/readme.md)                             | Forbids the usage of external ReferenceObjects                                 |                                             |
+| [`no-inline-enums`](./src/rules/no-inline-enums/readme.md)                               | Enums must be in `DefinitionsObject` or `ComponentsObject`                     |                                             |
+| [`no-ref-properties`](./src/rules/no-ref-properties/readme.md)                           | Disallows to have additional properties in Reference objects                   |                                             |
+| [`no-single-allof`](./src/rules/no-single-allof/readme.md)                               | Object types should not have a redundant single `allOf` property               |                                             |
+| [`no-trailing-slash`](./src/rules/no-trailing-slash/readme.md)                           | URLs must NOT end with a slash                                                 |                                             |
+| [`object-prop-casing`](./src/rules/object-prop-casing/readme.md)                         | Casing for your object property names                                          | ["camel"]                                   |
+| [`only-valid-mime-types`](./src/rules/only-valid-mime-types/readme.md)                   | Checks mime types against known from [`mime-db`](https://npm.im/mime-db)       |                                             |
+| [`parameter-casing`](./src/rules/parameter-casing/readme.md)                             | Casing for your parameters                                                     | ["camel",{"header":"kebab"}]                |
+| [`path-param-required-field`](./src/rules/path-param-required-field/readme.md)           | Helps to keep consistently set optional `required` property in path parameters |                                             |
+| [`required-operation-tags`](./src/rules/required-operation-tags/readme.md)               | All operations must have tags                                                  |                                             |
+| [`required-parameter-description`](./src/rules/required-parameter-description/readme.md) | All parameters must have description                                           |                                             |
+| [`required-tag-description`](./src/rules/required-tag-description/readme.md)             | All tags must have description                                                 |                                             |
 
 <!-- GENERATED_END(id:rulestable) -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1650,6 +1650,13 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+                }
             }
         },
         "char-regex": {
@@ -2060,9 +2067,9 @@
             }
         },
         "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         },
         "escodegen": {
             "version": "1.14.3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "ajv": "^6.12.6",
         "case": "1.6.3",
         "cosmiconfig": "7.0.0",
+        "escape-string-regexp": "4.0.0",
         "js-yaml": "3.14.0",
         "kleur": "^4.1.3",
         "lodash.get": "4.4.2",

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -3,7 +3,7 @@ import {SwaggerlintConfig} from './types';
 const config: SwaggerlintConfig = {
     rules: {
         'expressive-path-summary': true,
-        'latin-definitions-only': true,
+        'latin-definitions-only': ['', {ignore: []}],
         'no-empty-object-type': true,
         'no-external-refs': false,
         'no-inline-enums': true,

--- a/src/rules/latin-definitions-only/index.ts
+++ b/src/rules/latin-definitions-only/index.ts
@@ -48,6 +48,8 @@ const rule = createRule({
                             type: 'array',
                             items: {
                                 type: 'string',
+                                minLength: 1,
+                                maxLength: 1,
                             },
                         },
                     },

--- a/src/rules/latin-definitions-only/index.ts
+++ b/src/rules/latin-definitions-only/index.ts
@@ -1,16 +1,27 @@
+import escapeStringRegexp from 'escape-string-regexp';
 import {componentsKeys} from '../../utils/openapi';
 import {createRule} from '../../utils';
 
 const name = 'latin-definitions-only';
 
-function hasNonLatinCharacters(str: string): boolean {
+function replaceLatinCharacters(str: string): string {
     return (
         str
             // def name may contain latin chars
-            .replace(/[a-z]+/i, '')
+            .replace(/[a-z]+/gi, '')
             // or numerals
-            .replace(/\d/gi, '').length > 0
+            .replace(/\d/gi, '')
     );
+}
+
+function replaceIgnoredChars(str: string, ignoredChars: string[]): string {
+    if (ignoredChars.length === 0) return str;
+
+    const re = new RegExp(
+        `[${ignoredChars.map(x => escapeStringRegexp(x)).join('')}]`,
+        'g',
+    );
+    return str.replace(re, '');
 }
 
 const rule = createRule({
@@ -23,12 +34,40 @@ const rule = createRule({
         messages: {
             msg: `Definition name "{{name}}" contains non latin characters.`,
         },
+        schema: {
+            type: 'array',
+            items: [
+                {
+                    type: 'string',
+                },
+                {
+                    type: 'object',
+                    required: ['ignore'],
+                    properties: {
+                        ignore: {
+                            type: 'array',
+                            items: {
+                                type: 'string',
+                            },
+                        },
+                    },
+                },
+            ],
+            minItems: 1,
+            maxItems: 2,
+        },
     },
     swaggerVisitor: {
-        DefinitionsObject: ({node, report, location}): void => {
+        DefinitionsObject: ({node, report, location, setting}): void => {
+            const charsToIgnore = (Array.isArray(setting)
+                ? setting[1]?.ignore || []
+                : []) as string[];
             const definitionNames = Object.keys(node);
             definitionNames.forEach(name => {
-                if (hasNonLatinCharacters(name)) {
+                const cleanStr = replaceLatinCharacters(name);
+                const rest = replaceIgnoredChars(cleanStr, charsToIgnore);
+
+                if (rest.length > 0) {
                     report({
                         messageId: 'msg',
                         data: {
@@ -41,12 +80,18 @@ const rule = createRule({
         },
     },
     openapiVisitor: {
-        ComponentsObject: ({node, location, report}): void => {
+        ComponentsObject: ({node, location, report, setting}): void => {
+            const charsToIgnore = (Array.isArray(setting)
+                ? setting[1]?.ignore || []
+                : []) as string[];
             componentsKeys.forEach(compName => {
                 const val = node[compName];
                 if (val === undefined) return;
                 Object.keys(val).forEach(recName => {
-                    if (hasNonLatinCharacters(recName)) {
+                    const cleanStr = replaceLatinCharacters(recName);
+                    const rest = replaceIgnoredChars(cleanStr, charsToIgnore);
+
+                    if (rest.length > 0) {
                         report({
                             messageId: 'msg',
                             data: {
@@ -59,6 +104,7 @@ const rule = createRule({
             });
         },
     },
+    defaultSetting: ['placeholder_to_be_removed', {ignore: []}],
 });
 
 export default rule;

--- a/src/rules/latin-definitions-only/readme.md
+++ b/src/rules/latin-definitions-only/readme.md
@@ -23,3 +23,21 @@ components:
         "тоже невалидное название": # <-- invalid
             type: "number"
 ```
+
+## Configuration
+
+This rule can be configured to ignore specified characters.
+
+```js
+// swaggerlint.config.js
+module.exports = {
+    rules: {
+        'latin-definitions-only': [
+            '',
+            {
+                ignore: ['$', '#'], // characters to ignore
+            },
+        ],
+    },
+};
+```

--- a/src/rules/latin-definitions-only/spec/index.spec.ts
+++ b/src/rules/latin-definitions-only/spec/index.spec.ts
@@ -40,6 +40,58 @@ ruleTester.run({
         ],
         invalid: [
             {
+                it: 'should error for absent ignore option',
+                schema: {
+                    definitions: {
+                        valid: {
+                            type: 'object',
+                        },
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: ['foo', {}],
+                        'expressive-path-summary': true,
+                    },
+                },
+                errors: [
+                    {
+                        msg:
+                            "Should have required property 'ignore', got object",
+                        name: rule.name,
+                        location: [],
+                    },
+                ],
+            },
+            {
+                it: 'should error for all non single char config options',
+                schema: {
+                    definitions: {
+                        valid: {
+                            type: 'object',
+                        },
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: ['foo', {ignore: ['', '12']}],
+                        'expressive-path-summary': true,
+                    },
+                },
+                errors: [
+                    {
+                        msg: 'Invalid rule setting.',
+                        name: rule.name,
+                        location: [],
+                    },
+                    {
+                        msg: 'Invalid rule setting.',
+                        name: rule.name,
+                        location: [],
+                    },
+                ],
+            },
+            {
                 it: 'should error for all non latin named definitions',
                 schema: {
                     definitions: {

--- a/src/rules/latin-definitions-only/spec/index.spec.ts
+++ b/src/rules/latin-definitions-only/spec/index.spec.ts
@@ -64,6 +64,49 @@ ruleTester.run({
                     },
                 ],
             },
+            {
+                it: 'should error for non latin & non ignored definitoins',
+                schema: {
+                    definitions: {
+                        valid: {
+                            type: 'object',
+                        },
+                        '^invalid^': {
+                            type: 'object',
+                        },
+                        '&invalid&': {
+                            type: 'object',
+                        },
+                        $invalid$: {
+                            type: 'object',
+                        },
+                        '«invalid»': {
+                            type: 'object',
+                        },
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: ['', {ignore: ['$', '«', '»']}],
+                    },
+                },
+                errors: [
+                    {
+                        name: 'latin-definitions-only',
+                        msg:
+                            'Definition name "^invalid^" contains non latin characters.',
+                        messageId: 'msg',
+                        location: ['definitions', '^invalid^'],
+                    },
+                    {
+                        name: 'latin-definitions-only',
+                        msg:
+                            'Definition name "&invalid&" contains non latin characters.',
+                        messageId: 'msg',
+                        location: ['definitions', '&invalid&'],
+                    },
+                ],
+            },
         ],
     },
     openapi: {
@@ -97,6 +140,26 @@ ruleTester.run({
                     },
                 },
             },
+            {
+                it: 'should not error for ignored characters',
+                schema: {
+                    components: {
+                        schemas: {
+                            valid: {
+                                type: 'object',
+                            },
+                            'invalid-obj': {
+                                type: 'object',
+                            },
+                        },
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: ['', {ignore: ['-']}],
+                    },
+                },
+            },
         ],
         invalid: [
             {
@@ -123,6 +186,41 @@ ruleTester.run({
                             'Definition name "invalid-obj" contains non latin characters.',
                         name: rule.name,
                         location: ['components', 'schemas', 'invalid-obj'],
+                    },
+                ],
+            },
+            {
+                it: 'should error for non non ignored characters',
+                schema: {
+                    components: {
+                        schemas: {
+                            valid: {
+                                type: 'object',
+                            },
+                            $ignored$: {
+                                type: 'object',
+                            },
+                            '^invalid^': {
+                                type: 'object',
+                            },
+                        },
+                    },
+                },
+                config: {
+                    rules: {
+                        [rule.name]: ['', {ignore: ['$']}],
+                    },
+                },
+                errors: [
+                    {
+                        data: {
+                            name: '^invalid^',
+                        },
+                        messageId: 'msg',
+                        msg:
+                            'Definition name "^invalid^" contains non latin characters.',
+                        name: rule.name,
+                        location: ['components', 'schemas', '^invalid^'],
                     },
                 ],
             },

--- a/src/swaggerlint.ts
+++ b/src/swaggerlint.ts
@@ -160,6 +160,11 @@ export function swaggerlint(
                             case 'minItems':
                                 err.msg = `Rule setting ${se.message}`;
                                 break;
+                            case 'type':
+                                err.msg = `Value ${
+                                    se.message
+                                }, got ${typeof se.data}`;
+                                break;
                         }
 
                         errors.push(err);

--- a/src/swaggerlint.ts
+++ b/src/swaggerlint.ts
@@ -12,7 +12,7 @@ import {
     RuleVisitorFunction,
     OpenAPITypes,
 } from './types';
-import {isValidSwaggerVisitorName, hasKey} from './utils';
+import {isValidSwaggerVisitorName, hasKey, capitalize} from './utils';
 import {validate} from './utils/validate-json';
 
 import {isSwaggerObject} from './utils/swagger';
@@ -159,6 +159,11 @@ export function swaggerlint(
                                 break;
                             case 'minItems':
                                 err.msg = `Rule setting ${se.message}`;
+                                break;
+                            case 'required':
+                                err.msg = `${capitalize(
+                                    se.message || 'Missing required field',
+                                )}, got ${typeof se.data}`;
                                 break;
                             case 'type':
                                 err.msg = `Value ${

--- a/src/types/swaggerlint.ts
+++ b/src/types/swaggerlint.ts
@@ -349,6 +349,9 @@ type SwaggerlintRuleWithSetting<T extends string> = Omit<
     'meta'
 > & {
     meta: SwaggerlintRulePrimitive<T>['meta'] & {
+        /**
+         * JSONSchema for rule options
+         */
         schema: JSONSchema7;
     };
     /**

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -33,3 +33,7 @@ export function omit<T, S extends string>(src: T, fields: S[]): Omit<T, S> {
         return acc;
     }, {} as Omit<T, S>);
 }
+
+export function capitalize(str: string): string {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+}


### PR DESCRIPTION
This introduces `ignore` option for `latin-definions-only` rule. 

ATM it is rather suboptinal, since by the types [rule settings](https://github.com/antonk52/swaggerlint/blob/master/src/types/swaggerlint.ts#L28-L31) have to be either a boolean or an array. At this point this would be more intuitive to turn into either boolean or an object. However this would be a breaking change for other rules.

fixes #54 